### PR TITLE
add support to filters/sections

### DIFF
--- a/Sources/Gitbar/App.swift
+++ b/Sources/Gitbar/App.swift
@@ -108,7 +108,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupPanel() {
-        let rect = NSRect(x: 0, y: 0, width: 440, height: 580)
+        let rect = NSRect(x: 0, y: 0, width: 520, height: 620)
         panel = FloatingPanel(
             contentRect: rect,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -146,7 +146,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func refreshBadge() {
         guard let button = statusItem.button else { return }
-        let total = store.myPRs.count + store.reviewRequests.count + store.issues.count
+        let total = store.badgeCount
         button.title = total > 0 ? " \(total)" : ""
         let changesOn = Self.defaultsBool("gitbar.notify.changesRequested", default: true)
         let changesCount = store.myPRsNeedingChanges.count
@@ -187,7 +187,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         clickOutsideMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown]
         ) { [weak self] _ in
-            Task { @MainActor in self?.hidePanel() }
+            Task { @MainActor in
+                guard !EmojiPaletteState.isOpen else { return }
+                self?.hidePanel()
+            }
         }
 
         if store.hasToken { store.refresh() }

--- a/Sources/Gitbar/Config.swift
+++ b/Sources/Gitbar/Config.swift
@@ -13,33 +13,70 @@ enum Config {
     }
 
     static func readStoredToken() -> String? {
-        guard
-            let data = try? Data(contentsOf: configURL),
-            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let gh = obj["github"] as? [String: Any],
-            let token = gh["token"] as? String
-        else { return nil }
-        return token
+        readRoot().github.token
     }
 
     static func saveToken(_ token: String) throws {
+        var root = readRoot()
+        root.github.token = token
+        try writeRoot(root)
+    }
+
+    static func readSectionsWithMigration() -> [PanelTab: [GitbarSection]] {
+        var root = readRoot()
+        if root.sections == nil && root.sectionsSeeded != true {
+            root.sections = GitbarSection.seededDefaults()
+            root.sectionsSeeded = true
+            try? writeRoot(root)
+        }
+        return root.sections ?? [:]
+    }
+
+    static func saveSections(_ sections: [PanelTab: [GitbarSection]]) throws {
+        var root = readRoot()
+        root.sections = sections
+        root.sectionsSeeded = true
+        try writeRoot(root)
+    }
+
+    static func withConfigMutation(_ mutate: (inout ConfigRoot) -> Void) throws {
+        var root = readRoot()
+        mutate(&root)
+        try writeRoot(root)
+    }
+}
+
+private extension Config {
+    static func readRoot() -> ConfigRoot {
+        guard let data = try? Data(contentsOf: configURL) else {
+            return ConfigRoot()
+        }
+        let decoder = JSONDecoder()
+        if let root = try? decoder.decode(ConfigRoot.self, from: data) {
+            return root
+        }
+        return ConfigRoot()
+    }
+
+    static func writeRoot(_ root: ConfigRoot) throws {
         let url = configURL
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        var root: [String: Any] = [:]
-        if let data = try? Data(contentsOf: url),
-           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            root = existing
-        }
-        var gh = (root["github"] as? [String: Any]) ?? [:]
-        gh["token"] = token
-        root["github"] = gh
-        let out = try JSONSerialization.data(
-            withJSONObject: root,
-            options: [.prettyPrinted, .sortedKeys]
-        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let out = try encoder.encode(root)
         try out.write(to: url, options: .atomic)
     }
+}
+
+struct ConfigRoot: Codable {
+    struct GitHubConfig: Codable {
+        var token: String?
+    }
+
+    var github: GitHubConfig = .init()
+    var sections: [PanelTab: [GitbarSection]]?
+    var sectionsSeeded: Bool?
 }

--- a/Sources/Gitbar/GitHub.swift
+++ b/Sources/Gitbar/GitHub.swift
@@ -50,6 +50,7 @@ struct GHIssue: Decodable, Identifiable, Hashable {
     let repositoryUrl: String
     let user: GHUser
     let labels: [GHLabel]
+    let assignees: [GHUser]?
     let draft: Bool?
     let pullRequest: GHPullRequestRef?
     /// Present on search/API responses; used for stats (merge latency).
@@ -58,7 +59,7 @@ struct GHIssue: Decodable, Identifiable, Hashable {
     let comments: Int
 
     enum CodingKeys: String, CodingKey {
-        case id, number, title, state, labels, draft, user, comments
+        case id, number, title, state, labels, assignees, draft, user, comments
         case htmlUrl = "html_url"
         case repositoryUrl = "repository_url"
         case pullRequest = "pull_request"
@@ -156,7 +157,7 @@ struct GHCheckRun: Decodable {
 }
 
 /// CI aggregate for the menu bar row (left pill).
-enum CIPillKind: String, Equatable, Sendable {
+enum CIPillKind: String, Codable, Equatable, Sendable, Hashable, CaseIterable {
     case pass
     case fail
     case running

--- a/Sources/Gitbar/Sections.swift
+++ b/Sources/Gitbar/Sections.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+enum RepoScope: Codable, Equatable, Sendable {
+    case defaults
+    case explicit([String])
+}
+
+enum SectionVisibility: String, Codable, CaseIterable, Equatable, Sendable {
+    case visible
+    case collapsedByDefault
+    case hidden
+}
+
+enum SortChoice: String, Codable, CaseIterable, Equatable, Sendable {
+    case updatedDesc
+    case updatedAsc
+    case repo
+
+    var label: String {
+        switch self {
+        case .updatedDesc: return "Newest"
+        case .updatedAsc: return "Oldest"
+        case .repo: return "Repo"
+        }
+    }
+}
+
+struct SectionFilter: Codable, Equatable, Sendable {
+    var conditions: [SectionCondition]
+}
+
+enum SectionSetOp: String, Codable, Equatable, Sendable {
+    case includes
+    case excludes
+}
+
+enum SectionEqOp: String, Codable, Equatable, Sendable {
+    case is_
+    case isNot
+}
+
+enum SectionPRStatusValue: String, Codable, CaseIterable, Equatable, Sendable {
+    case open = "Open"
+    case closed = "Closed"
+    case merged = "Merged"
+    case merging = "Merging"
+}
+
+enum SectionCondition: Codable, Equatable, Sendable {
+    case prStatus(op: SectionSetOp, values: [SectionPRStatusValue])
+    case author(op: SectionEqOp, login: String)
+    case reviewer(op: SectionSetOp, login: String)
+    case repository(op: SectionSetOp, repos: [String])
+    case ciStatus(op: SectionSetOp, values: [CIPillKind])
+    case draft(is: Bool)
+    case label(op: SectionSetOp, name: String)
+    case assignee(op: SectionSetOp, login: String)
+    case hasMergeConflict(is: Bool)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, op, values, login, repos, isDraft, name, isOn
+    }
+
+    private enum Kind: String, Codable {
+        case prStatus, author, reviewer, repository, ciStatus, draft
+        case label, assignee, hasMergeConflict
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try c.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .prStatus:
+            self = .prStatus(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                values: try c.decode([SectionPRStatusValue].self, forKey: .values)
+            )
+        case .author:
+            self = .author(
+                op: try c.decode(SectionEqOp.self, forKey: .op),
+                login: try c.decode(String.self, forKey: .login)
+            )
+        case .reviewer:
+            self = .reviewer(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                login: try c.decode(String.self, forKey: .login)
+            )
+        case .repository:
+            self = .repository(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                repos: try c.decode([String].self, forKey: .repos)
+            )
+        case .ciStatus:
+            self = .ciStatus(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                values: try c.decode([CIPillKind].self, forKey: .values)
+            )
+        case .draft:
+            self = .draft(is: try c.decode(Bool.self, forKey: .isDraft))
+        case .label:
+            self = .label(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                name: try c.decode(String.self, forKey: .name)
+            )
+        case .assignee:
+            self = .assignee(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                login: try c.decode(String.self, forKey: .login)
+            )
+        case .hasMergeConflict:
+            self = .hasMergeConflict(is: try c.decode(Bool.self, forKey: .isOn))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .prStatus(let op, let values):
+            try c.encode(Kind.prStatus, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(values, forKey: .values)
+        case .author(let op, let login):
+            try c.encode(Kind.author, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(login, forKey: .login)
+        case .reviewer(let op, let login):
+            try c.encode(Kind.reviewer, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(login, forKey: .login)
+        case .repository(let op, let repos):
+            try c.encode(Kind.repository, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(repos, forKey: .repos)
+        case .ciStatus(let op, let values):
+            try c.encode(Kind.ciStatus, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(values, forKey: .values)
+        case .draft(let isDraft):
+            try c.encode(Kind.draft, forKey: .kind)
+            try c.encode(isDraft, forKey: .isDraft)
+        case .label(let op, let name):
+            try c.encode(Kind.label, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(name, forKey: .name)
+        case .assignee(let op, let login):
+            try c.encode(Kind.assignee, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(login, forKey: .login)
+        case .hasMergeConflict(let isOn):
+            try c.encode(Kind.hasMergeConflict, forKey: .kind)
+            try c.encode(isOn, forKey: .isOn)
+        }
+    }
+}
+
+struct GitbarSection: Codable, Identifiable, Equatable, Sendable {
+    var id: UUID
+    var name: String
+    var icon: String? = nil
+    var tab: PanelTab
+    var repos: RepoScope
+    var filters: [SectionFilter]
+    var visibility: SectionVisibility
+    var contributesToBadge: Bool
+    var sort: SortChoice
+    var collapsed: Bool
+    var order: Int
+    var isDefault: Bool = false
+}
+
+extension GitbarSection {
+    static func seededDefaults() -> [PanelTab: [GitbarSection]] {
+        [
+            .mine: seededMine(),
+            .review: seededReview(),
+            .issues: seededIssues(),
+        ]
+    }
+
+    static func seededMine() -> [GitbarSection] {
+        [
+            GitbarSection(
+                id: UUID(),
+                name: "Needs changes",
+                tab: .mine,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.prStatus(op: .includes, values: [.open])])],
+                visibility: .visible,
+                contributesToBadge: true,
+                sort: .updatedDesc,
+                collapsed: false,
+                order: 0,
+                isDefault: true
+            ),
+            GitbarSection(
+                id: UUID(),
+                name: "Drafts",
+                tab: .mine,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.draft(is: true)])],
+                visibility: .collapsedByDefault,
+                contributesToBadge: false,
+                sort: .updatedDesc,
+                collapsed: true,
+                order: 1,
+                isDefault: true
+            ),
+            GitbarSection(
+                id: UUID(),
+                name: "CI failing",
+                tab: .mine,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.ciStatus(op: .includes, values: [.fail])])],
+                visibility: .visible,
+                contributesToBadge: true,
+                sort: .updatedDesc,
+                collapsed: false,
+                order: 2,
+                isDefault: true
+            ),
+        ]
+    }
+
+    static func seededReview() -> [GitbarSection] {
+        [
+            GitbarSection(
+                id: UUID(),
+                name: "Ready",
+                tab: .review,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.draft(is: false)])],
+                visibility: .visible,
+                contributesToBadge: true,
+                sort: .updatedDesc,
+                collapsed: false,
+                order: 0,
+                isDefault: true
+            ),
+            GitbarSection(
+                id: UUID(),
+                name: "Drafts",
+                tab: .review,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.draft(is: true)])],
+                visibility: .collapsedByDefault,
+                contributesToBadge: false,
+                sort: .updatedDesc,
+                collapsed: true,
+                order: 1,
+                isDefault: true
+            ),
+            GitbarSection(
+                id: UUID(),
+                name: "Blocked on CI",
+                tab: .review,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.ciStatus(op: .includes, values: [.fail, .running])])],
+                visibility: .visible,
+                contributesToBadge: false,
+                sort: .updatedDesc,
+                collapsed: false,
+                order: 2,
+                isDefault: true
+            ),
+        ]
+    }
+
+    static func seededIssues() -> [GitbarSection] {
+        [
+            GitbarSection(
+                id: UUID(),
+                name: "Assigned issues",
+                tab: .issues,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [.prStatus(op: .includes, values: [.open])])],
+                visibility: .visible,
+                contributesToBadge: false,
+                sort: .updatedDesc,
+                collapsed: false,
+                order: 0,
+                isDefault: true
+            ),
+        ]
+    }
+}
+
+struct SectionMatcher {
+    static func matches(
+        section: GitbarSection,
+        row: GHIssue,
+        viewerLogin: String?,
+        metadata: PRRowMetadata?,
+        reviewState: String?
+    ) -> Bool {
+        if section.filters.isEmpty { return false }
+        return section.filters.contains { allConditionsMatch($0.conditions, row: row, viewerLogin: viewerLogin, metadata: metadata, reviewState: reviewState) }
+    }
+
+    private static func allConditionsMatch(
+        _ conditions: [SectionCondition],
+        row: GHIssue,
+        viewerLogin: String?,
+        metadata: PRRowMetadata?,
+        reviewState: String?
+    ) -> Bool {
+        guard !conditions.isEmpty else { return false }
+        return conditions.allSatisfy { condition in
+            switch condition {
+            case .prStatus(let op, let values):
+                let status = issueStatus(row: row)
+                // `.merging` was a broken legacy value; treat it as `.merged` for old configs.
+                let normalizedValues = Set(values.map { $0 == .merging ? .merged : $0 })
+                return includesEval(op: op, inSet: normalizedValues.contains(status))
+            case .author(let op, let login):
+                let equals = row.user.login.caseInsensitiveCompare(login) == .orderedSame
+                return op == .is_ ? equals : !equals
+            case .reviewer:
+                // Requested-reviewers aren't exposed by the search API; this filter
+                // cannot be evaluated reliably, so it never matches.
+                return false
+            case .repository(let op, let repos):
+                let repo = row.repoFull.lowercased()
+                let has = repos.map { $0.lowercased() }.contains(repo)
+                return includesEval(op: op, inSet: has)
+            case .ciStatus(let op, let values):
+                let ci = metadata?.ci ?? .unknown
+                return includesEval(op: op, inSet: values.contains(ci))
+            case .draft(let isDraft):
+                return row.isDraft == isDraft
+            case .label(let op, let name):
+                let needle = name.lowercased()
+                let has = row.labels.contains { $0.name.lowercased() == needle }
+                return includesEval(op: op, inSet: has)
+            case .assignee(let op, let login):
+                let needle = login.lowercased()
+                let has = (row.assignees ?? []).contains { $0.login.lowercased() == needle }
+                return includesEval(op: op, inSet: has)
+            case .hasMergeConflict(let expected):
+                let actual = metadata?.hasMergeConflict ?? false
+                return actual == expected
+            }
+        }
+    }
+
+    private static func includesEval(op: SectionSetOp, inSet: Bool) -> Bool {
+        op == .includes ? inSet : !inSet
+    }
+
+    private static func issueStatus(row: GHIssue) -> SectionPRStatusValue {
+        if row.state.lowercased() == "open" { return .open }
+        return row.pullRequest?.mergedAt != nil ? .merged : .closed
+    }
+}

--- a/Sources/Gitbar/Store.swift
+++ b/Sources/Gitbar/Store.swift
@@ -20,6 +20,7 @@ final class Store: ObservableObject {
     @Published var lastRefreshed: Date?
     @Published var errorMessage: String?
     @Published var token: String?
+    @Published var sectionsByTab: [PanelTab: [GitbarSection]] = [:]
 
     /// Stats tab (`StatsLoader` + GitHub Search / events).
     @Published private(set) var statsSnapshot: StatsSnapshot?
@@ -35,6 +36,7 @@ final class Store: ObservableObject {
 
     init() {
         self.token = Config.resolveToken()
+        self.sectionsByTab = Config.readSectionsWithMigration()
     }
 
     var hasToken: Bool {
@@ -55,6 +57,42 @@ final class Store: ObservableObject {
     /// Open PRs you authored whose latest review outcome is changes requested.
     var myPRsNeedingChanges: [GHIssue] {
         myPRs.filter { myPRReviewState[$0.id] == "CHANGES_REQUESTED" }
+    }
+
+    var badgeCount: Int {
+        let badgedSections = sectionsByTab.values
+            .flatMap { $0 }
+            .filter { $0.contributesToBadge }
+        guard !badgedSections.isEmpty else {
+            return myPRs.count + reviewRequests.count + issues.count
+        }
+
+        var ids = Set<Int>()
+        for section in badgedSections {
+            let source: [GHIssue]
+            switch section.tab {
+            case .mine:
+                source = myPRs
+            case .review:
+                source = reviewRequests
+            case .issues:
+                source = issues
+            case .all, .stats:
+                source = []
+            }
+            for row in source {
+                if SectionMatcher.matches(
+                    section: section,
+                    row: row,
+                    viewerLogin: myLogin,
+                    metadata: prRowMetadata[row.id],
+                    reviewState: myPRReviewState[row.id]
+                ) {
+                    ids.insert(row.id)
+                }
+            }
+        }
+        return ids.count
     }
 
     func refresh() {
@@ -139,6 +177,81 @@ final class Store: ObservableObject {
         if !trimmed.isEmpty {
             refresh()
         }
+    }
+
+    func sections(for tab: PanelTab) -> [GitbarSection] {
+        (sectionsByTab[tab] ?? []).sorted(by: { $0.order < $1.order })
+    }
+
+    func updateSection(_ section: GitbarSection) {
+        var next = sectionsByTab
+        var list = next[section.tab] ?? []
+        if let idx = list.firstIndex(where: { $0.id == section.id }) {
+            list[idx] = section
+            next[section.tab] = list
+            sectionsByTab = next
+            try? Config.saveSections(next)
+        }
+    }
+
+    func addSection(_ section: GitbarSection) {
+        var next = sectionsByTab
+        var list = next[section.tab] ?? []
+        var toInsert = section
+        toInsert.order = (list.map(\.order).max() ?? -1) + 1
+        list.append(toInsert)
+        next[section.tab] = list
+        sectionsByTab = next
+        try? Config.saveSections(next)
+    }
+
+    func deleteSection(id: UUID, tab: PanelTab) {
+        var next = sectionsByTab
+        guard var list = next[tab] else { return }
+        // Default sections are structural; refuse deletion even if called directly.
+        guard list.first(where: { $0.id == id })?.isDefault != true else { return }
+        list.removeAll { $0.id == id }
+        next[tab] = list
+        sectionsByTab = next
+        try? Config.saveSections(next)
+    }
+
+    /// Moves `id` within `tab`. When `targetID` is nil, appends to the end.
+    /// Ignores moves from other tabs (cross-tab drag not supported in v1).
+    func reorderSection(in tab: PanelTab, moving id: UUID, before targetID: UUID?) {
+        var next = sectionsByTab
+        guard var list = next[tab],
+              let fromIdx = list.firstIndex(where: { $0.id == id }) else { return }
+        let moved = list.remove(at: fromIdx)
+        if let targetID, let targetIdx = list.firstIndex(where: { $0.id == targetID }) {
+            list.insert(moved, at: targetIdx)
+        } else {
+            list.append(moved)
+        }
+        for i in list.indices { list[i].order = i }
+        next[tab] = list
+        sectionsByTab = next
+        try? Config.saveSections(next)
+    }
+
+    func toggleSectionCollapsed(tab: PanelTab, id: UUID) {
+        var next = sectionsByTab
+        guard var list = next[tab],
+              let idx = list.firstIndex(where: { $0.id == id }) else { return }
+        list[idx].collapsed.toggle()
+        next[tab] = list
+        sectionsByTab = next
+        try? Config.saveSections(next)
+    }
+
+    func updateSectionSort(tab: PanelTab, id: UUID, sort: SortChoice) {
+        var next = sectionsByTab
+        guard var list = next[tab],
+              let idx = list.firstIndex(where: { $0.id == id }) else { return }
+        list[idx].sort = sort
+        next[tab] = list
+        sectionsByTab = next
+        try? Config.saveSections(next)
     }
 
     /// Applies `UserDefaults` key `gitbar.refreshInterval` (30s / 60s / 5m / manual).

--- a/Sources/Gitbar/Theme.swift
+++ b/Sources/Gitbar/Theme.swift
@@ -69,5 +69,5 @@ enum Theme {
     }
 
     static let mono     = Font.system(.caption, design: .monospaced)
-    static let monoTiny = Font.system(size: 10.5, design: .monospaced)
+    static let monoTiny = Font.system(size: 9.5, design: .monospaced)
 }

--- a/Sources/Gitbar/Views/EmojiCaptureField.swift
+++ b/Sources/Gitbar/Views/EmojiCaptureField.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import AppKit
+
+/// Suppresses the app's global click-outside dismissal while the character
+/// palette is open, so selecting an emoji doesn't close the menu-bar panel.
+@MainActor
+enum EmojiPaletteState {
+    static var isOpen: Bool = false
+}
+
+/// Invisible text field that triggers the macOS character palette and captures
+/// the first emoji character the user picks. Set `requestFocus = true` to open
+/// the picker; the first emoji lands in `selected`.
+struct EmojiCaptureField: NSViewRepresentable {
+    @Binding var selected: String?
+    @Binding var requestFocus: Bool
+
+    func makeNSView(context: Context) -> CaptureField {
+        let field = CaptureField()
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: 1)
+        field.textColor = .clear
+        field.delegate = context.coordinator
+        field.refusesFirstResponder = false
+        return field
+    }
+
+    func updateNSView(_ nsView: CaptureField, context: Context) {
+        if requestFocus {
+            DispatchQueue.main.async {
+                nsView.window?.makeFirstResponder(nsView)
+                EmojiPaletteState.isOpen = true
+                NSApp.orderFrontCharacterPalette(nil)
+                self.requestFocus = false
+                // Safety reset — in case the user dismisses the palette without
+                // picking anything, we don't want to freeze the panel forever.
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 60_000_000_000)
+                    EmojiPaletteState.isOpen = false
+                }
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selected: $selected)
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        let selected: Binding<String?>
+
+        init(selected: Binding<String?>) {
+            self.selected = selected
+        }
+
+        func controlTextDidChange(_ note: Notification) {
+            guard let field = note.object as? NSTextField else { return }
+            let value = field.stringValue
+            defer {
+                field.stringValue = ""
+                Task { @MainActor in EmojiPaletteState.isOpen = false }
+            }
+            guard let emoji = Self.firstEmoji(in: value) else { return }
+            selected.wrappedValue = emoji
+        }
+
+        static func firstEmoji(in value: String) -> String? {
+            for char in value {
+                if char.unicodeScalars.contains(where: { $0.properties.isEmoji })
+                    && char.unicodeScalars.contains(where: {
+                        $0.properties.isEmojiPresentation
+                            || $0.value >= 0x1F000
+                    })
+                {
+                    return String(char)
+                }
+            }
+            return nil
+        }
+    }
+
+    final class CaptureField: NSTextField {
+        override var acceptsFirstResponder: Bool { true }
+    }
+}

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import AppKit
 
-enum PanelTab: String, CaseIterable, Identifiable {
+enum PanelTab: String, CaseIterable, Identifiable, Codable, Sendable {
     case all, mine, review, issues, stats
     var id: String { rawValue }
     var label: String {
@@ -21,25 +21,15 @@ enum PanelTab: String, CaseIterable, Identifiable {
     }
 }
 
-private enum PanelListEntry: Identifiable, Hashable {
-    case mine(GHIssue)
-    case review(GHIssue)
-    case issue(GHIssue)
+private struct PanelListEntry: Identifiable, Hashable {
+    let id: String
+    let htmlURL: String
+}
 
-    var id: String {
-        switch self {
-        case .mine(let i): return "m-\(i.id)"
-        case .review(let i): return "r-\(i.id)"
-        case .issue(let i): return "i-\(i.id)"
-        }
-    }
-
-    var htmlURL: String {
-        switch self {
-        case .mine(let i), .review(let i), .issue(let i):
-            return i.htmlUrl
-        }
-    }
+private struct TabSectionRows: Identifiable {
+    let section: GitbarSection
+    let rows: [GHIssue]
+    var id: UUID { section.id }
 }
 
 struct PanelView: View {
@@ -47,13 +37,19 @@ struct PanelView: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var tab: PanelTab = .all
     @State private var selectedIndex: Int = 0
+    @State private var editorState: SectionEditorMode?
+    @State private var managingSections: Bool = false
     @FocusState private var listKeyboardFocused: Bool
+
+    private var isOverlayActive: Bool { managingSections || editorState != nil }
+    private let panelWidth: CGFloat = 520
+    private let panelHeight: CGFloat = 620
 
     let onOpenSettings: () -> Void
 
     var body: some View {
         panelChrome
-            .frame(width: 440, height: 580)
+            .frame(width: panelWidth, height: panelHeight)
             .background(panelBackdrop)
             .focusable()
             .focused($listKeyboardFocused)
@@ -92,16 +88,26 @@ struct PanelView: View {
     @ViewBuilder
     private var panelChrome: some View {
         VStack(spacing: 0) {
-            tabBar
-                .animation(.easeInOut(duration: 0.16), value: tab)
-            panelDivider
+            if !isOverlayActive {
+                tabBar
+                    .animation(.easeInOut(duration: 0.16), value: tab)
+                panelDivider
+            }
             content
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .id(tab)
+                .id(overlayIdentity)
                 .transition(.opacity)
-            panelDivider
-            footer
+            if !isOverlayActive {
+                panelDivider
+                footer
+            }
         }
+    }
+
+    private var overlayIdentity: String {
+        if editorState != nil { return "editor" }
+        if managingSections { return "manager" }
+        return tab.rawValue
     }
 
     private func handleKeyPress(_ press: KeyPress) -> KeyPress.Result {
@@ -127,7 +133,7 @@ struct PanelView: View {
     }
 
     private var listSignature: String {
-        "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.issues.map(\.id))"
+        "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))"
     }
 
     private var navigableItems: [PanelListEntry] {
@@ -136,16 +142,71 @@ struct PanelView: View {
             return []
         case .all:
             var rows: [PanelListEntry] = []
-            rows.append(contentsOf: store.myPRs.map { .mine($0) })
-            rows.append(contentsOf: store.reviewRequests.map { .review($0) })
-            rows.append(contentsOf: store.issues.map { .issue($0) })
+            rows.append(contentsOf: store.myPRs.map { PanelListEntry(id: "all-m-\($0.id)", htmlURL: $0.htmlUrl) })
+            rows.append(contentsOf: store.reviewRequests.map { PanelListEntry(id: "all-r-\($0.id)", htmlURL: $0.htmlUrl) })
+            rows.append(contentsOf: store.issues.map { PanelListEntry(id: "all-i-\($0.id)", htmlURL: $0.htmlUrl) })
             return rows
         case .mine:
-            return store.myPRs.map { .mine($0) }
+            return sectionEntries(for: .mine, sourceRows: store.myPRs)
         case .review:
-            return store.reviewRequests.map { .review($0) }
+            return sectionEntries(for: .review, sourceRows: store.reviewRequests)
         case .issues:
-            return store.issues.map { .issue($0) }
+            return sectionEntries(for: .issues, sourceRows: store.issues)
+        }
+    }
+
+    private func sectionEntries(for tab: PanelTab, sourceRows: [GHIssue]) -> [PanelListEntry] {
+        var items: [PanelListEntry] = []
+        for sectionRows in renderedSections(for: tab, sourceRows: sourceRows) {
+            guard !sectionRows.section.collapsed else { continue }
+            items.append(contentsOf: sectionRows.rows.map {
+                PanelListEntry(id: "sec-\(sectionRows.section.id.uuidString)-\($0.id)", htmlURL: $0.htmlUrl)
+            })
+        }
+        items.append(contentsOf: unmatchedRows(for: tab, sourceRows: sourceRows).map {
+            PanelListEntry(id: "all-\(tab.rawValue)-\($0.id)", htmlURL: $0.htmlUrl)
+        })
+        return items
+    }
+
+    private func renderedSections(for tab: PanelTab, sourceRows: [GHIssue]) -> [TabSectionRows] {
+        store.sections(for: tab)
+            .filter { $0.visibility != .hidden }
+            .map { section in
+                let rows = sourceRows.filter {
+                    SectionMatcher.matches(
+                        section: section,
+                        row: $0,
+                        viewerLogin: store.myLogin,
+                        metadata: store.prRowMetadata[$0.id],
+                        reviewState: store.myPRReviewState[$0.id]
+                    )
+                }
+                return TabSectionRows(section: section, rows: sort(rows, by: section.sort))
+            }
+            .filter { !$0.rows.isEmpty }
+    }
+
+    private func unmatchedRows(for tab: PanelTab, sourceRows: [GHIssue]) -> [GHIssue] {
+        let matchedIDs = Set(
+            renderedSections(for: tab, sourceRows: sourceRows)
+                .flatMap(\.rows)
+                .map(\.id)
+        )
+        return sourceRows.filter { !matchedIDs.contains($0.id) }
+    }
+
+    private func sort(_ rows: [GHIssue], by choice: SortChoice) -> [GHIssue] {
+        switch choice {
+        case .updatedDesc:
+            return rows.sorted { $0.updated > $1.updated }
+        case .updatedAsc:
+            return rows.sorted { $0.updated < $1.updated }
+        case .repo:
+            return rows.sorted {
+                if $0.repoFull == $1.repoFull { return $0.updated > $1.updated }
+                return $0.repoFull.localizedCaseInsensitiveCompare($1.repoFull) == .orderedAscending
+            }
         }
     }
 
@@ -236,6 +297,30 @@ struct PanelView: View {
                 tabButton(t)
             }
             Spacer(minLength: 4)
+            Menu {
+                Button {
+                    managingSections = true
+                } label: {
+                    Text("View filters")
+                }
+                if canCreateSectionForCurrentTab {
+                    Button {
+                        editorState = .create(tab)
+                    } label: {
+                        Text("Create filter in \(tab.label)")
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Filters")
             Button(action: onOpenSettings) {
                 Image(systemName: "gearshape")
                     .font(.system(size: 13, weight: .medium))
@@ -249,6 +334,13 @@ struct PanelView: View {
         .padding(.horizontal, 10)
         .padding(.top, 8)
         .padding(.bottom, 6)
+    }
+
+    private var canCreateSectionForCurrentTab: Bool {
+        switch tab {
+        case .mine, .review, .issues: return true
+        case .all, .stats: return false
+        }
     }
 
     private func tabButton(_ t: PanelTab) -> some View {
@@ -285,7 +377,36 @@ struct PanelView: View {
 
     @ViewBuilder
     private var content: some View {
-        if tab == .stats {
+        if let mode = editorState {
+            SectionEditorView(
+                mode: mode,
+                onSave: { section in
+                    switch mode {
+                    case .create: store.addSection(section)
+                    case .edit: store.updateSection(section)
+                    }
+                    editorState = nil
+                },
+                onDelete: {
+                    if case .edit(let section) = mode, !section.isDefault {
+                        store.deleteSection(id: section.id, tab: section.tab)
+                    }
+                    editorState = nil
+                },
+                onCancel: { editorState = nil }
+            )
+        } else if managingSections {
+            SectionsManagerView(
+                onCreate: { targetTab in
+                    editorState = .create(targetTab)
+                },
+                onEdit: { section in
+                    editorState = .edit(section)
+                },
+                onBack: { managingSections = false }
+            )
+            .environmentObject(store)
+        } else if tab == .stats {
             StatsView()
         } else if !store.hasToken {
             EmptyTokenState(onOpenSettings: onOpenSettings)
@@ -300,7 +421,7 @@ struct PanelView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        if showMine, !store.myPRs.isEmpty {
+                        if tab == .all, showMine, !store.myPRs.isEmpty {
                             SectionHeader(
                                 icon: .gitPullRequest,
                                 title: "My pull requests",
@@ -313,12 +434,12 @@ struct PanelView: View {
                                     showAuthor: false,
                                     reviewState: store.myPRReviewState[pr.id],
                                     metadata: store.prRowMetadata[pr.id],
-                                    isSelected: isEntrySelected(.mine(pr))
+                                    isSelected: isEntrySelected("all-m-\(pr.id)")
                                 )
-                                .id(PanelListEntry.mine(pr).id)
+                                .id("all-m-\(pr.id)")
                             }
                         }
-                        if showReview, !store.reviewRequests.isEmpty {
+                        if tab == .all, showReview, !store.reviewRequests.isEmpty {
                             SectionHeader(
                                 icon: .circleDotDashed,
                                 title: "Awaiting your review",
@@ -330,12 +451,12 @@ struct PanelView: View {
                                     pr: pr,
                                     showAuthor: true,
                                     metadata: store.prRowMetadata[pr.id],
-                                    isSelected: isEntrySelected(.review(pr))
+                                    isSelected: isEntrySelected("all-r-\(pr.id)")
                                 )
-                                .id(PanelListEntry.review(pr).id)
+                                .id("all-r-\(pr.id)")
                             }
                         }
-                        if showIssues, !store.issues.isEmpty {
+                        if tab == .all, showIssues, !store.issues.isEmpty {
                             SectionHeader(
                                 icon: .circleDot,
                                 title: "Assigned issues",
@@ -343,9 +464,18 @@ struct PanelView: View {
                                 accent: Theme.green
                             )
                             ForEach(store.issues) { issue in
-                                IssueRow(issue: issue, isSelected: isEntrySelected(.issue(issue)))
-                                    .id(PanelListEntry.issue(issue).id)
+                                IssueRow(issue: issue, isSelected: isEntrySelected("all-i-\(issue.id)"))
+                                    .id("all-i-\(issue.id)")
                             }
+                        }
+                        if tab == .mine {
+                            sectionDrivenList(tab: .mine, sourceRows: store.myPRs, showAuthor: false)
+                        }
+                        if tab == .review {
+                            sectionDrivenList(tab: .review, sourceRows: store.reviewRequests, showAuthor: true)
+                        }
+                        if tab == .issues {
+                            sectionDrivenIssues(tab: .issues, sourceRows: store.issues)
                         }
                         Color.clear.frame(height: 6)
                     }
@@ -363,11 +493,139 @@ struct PanelView: View {
         }
     }
 
-    private func isEntrySelected(_ entry: PanelListEntry) -> Bool {
+    private func isEntrySelected(_ entryID: String) -> Bool {
         guard !navigableItems.isEmpty,
               selectedIndex >= 0,
               selectedIndex < navigableItems.count else { return false }
-        return navigableItems[selectedIndex].id == entry.id
+        return navigableItems[selectedIndex].id == entryID
+    }
+
+    @ViewBuilder
+    private func sectionDrivenList(tab: PanelTab, sourceRows: [GHIssue], showAuthor: Bool) -> some View {
+        let sections = renderedSections(for: tab, sourceRows: sourceRows)
+        ForEach(sections) { sectionRows in
+            sectionHeader(tab: tab, section: sectionRows.section, count: sectionRows.rows.count)
+            if !sectionRows.section.collapsed {
+                ForEach(sectionRows.rows) { row in
+                    PRRow(
+                        pr: row,
+                        showAuthor: showAuthor,
+                        reviewState: store.myPRReviewState[row.id],
+                        metadata: store.prRowMetadata[row.id],
+                        isSelected: isEntrySelected("sec-\(sectionRows.section.id.uuidString)-\(row.id)")
+                    )
+                    .id("sec-\(sectionRows.section.id.uuidString)-\(row.id)")
+                }
+            }
+        }
+
+        let unmatched = unmatchedRows(for: tab, sourceRows: sourceRows)
+        if !unmatched.isEmpty {
+            SectionHeader(
+                icon: .circleDotDashed,
+                title: "All",
+                count: unmatched.count,
+                accent: .secondary
+            )
+            ForEach(unmatched) { row in
+                PRRow(
+                    pr: row,
+                    showAuthor: showAuthor,
+                    reviewState: store.myPRReviewState[row.id],
+                    metadata: store.prRowMetadata[row.id],
+                    isSelected: isEntrySelected("all-\(tab.rawValue)-\(row.id)")
+                )
+                .id("all-\(tab.rawValue)-\(row.id)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func sectionDrivenIssues(tab: PanelTab, sourceRows: [GHIssue]) -> some View {
+        let sections = renderedSections(for: tab, sourceRows: sourceRows)
+        ForEach(sections) { sectionRows in
+            sectionHeader(tab: tab, section: sectionRows.section, count: sectionRows.rows.count)
+            if !sectionRows.section.collapsed {
+                ForEach(sectionRows.rows) { row in
+                    IssueRow(
+                        issue: row,
+                        isSelected: isEntrySelected("sec-\(sectionRows.section.id.uuidString)-\(row.id)")
+                    )
+                    .id("sec-\(sectionRows.section.id.uuidString)-\(row.id)")
+                }
+            }
+        }
+
+        let unmatched = unmatchedRows(for: tab, sourceRows: sourceRows)
+        if !unmatched.isEmpty {
+            SectionHeader(
+                icon: .circleDotDashed,
+                title: "All",
+                count: unmatched.count,
+                accent: .secondary
+            )
+            ForEach(unmatched) { row in
+                IssueRow(
+                    issue: row,
+                    isSelected: isEntrySelected("all-\(tab.rawValue)-\(row.id)")
+                )
+                .id("all-\(tab.rawValue)-\(row.id)")
+            }
+        }
+    }
+
+    private func sectionHeader(tab: PanelTab, section: GitbarSection, count: Int) -> some View {
+        HStack(spacing: 6) {
+            if let icon = section.icon, !icon.isEmpty {
+                Text(icon).font(.system(size: 12))
+            }
+            Text(section.name.uppercased())
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.6)
+                .foregroundStyle(.secondary)
+            Text("\(count)")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1)
+                .background(Theme.surfaceHi(colorScheme), in: Capsule())
+            Spacer()
+            Menu {
+                ForEach(SortChoice.allCases, id: \.rawValue) { choice in
+                    Button(choice.label) {
+                        store.updateSectionSort(tab: tab, id: section.id, sort: choice)
+                    }
+                }
+            } label: {
+                Text(section.sort.label)
+                    .font(.system(size: 10.5, weight: .medium))
+                    .foregroundStyle(Theme.meta)
+            }
+            .menuStyle(.borderlessButton)
+            Menu {
+                Button("Edit…") {
+                    editorState = .edit(section)
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .frame(width: 18)
+            Button {
+                store.toggleSectionCollapsed(tab: tab, id: section.id)
+            } label: {
+                Image(systemName: section.collapsed ? "chevron.right" : "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 12)
+        .padding(.bottom, 4)
     }
 
     private var footer: some View {

--- a/Sources/Gitbar/Views/Rows.swift
+++ b/Sources/Gitbar/Views/Rows.swift
@@ -78,7 +78,7 @@ struct PRRow: View {
                         draftBadge
                     }
                     Text(pr.title)
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.system(size: 11.5, weight: .medium))
                         .foregroundStyle(.primary)
                         .lineLimit(2)
                         .truncationMode(.tail)
@@ -95,7 +95,7 @@ struct PRRow: View {
                     if showAuthor {
                         Text("·").foregroundStyle(Theme.faint.opacity(0.9))
                         Text("@\(pr.user.login)")
-                            .font(.system(size: 11))
+                            .font(.system(size: 10))
                             .foregroundStyle(.secondary)
                     }
 
@@ -109,7 +109,7 @@ struct PRRow: View {
                         HStack(spacing: 3) {
                             LucideRepoIconView(icon: .gitMergeConflict, size: 11, color: Theme.amber)
                             Text("conflict")
-                                .font(.system(size: 10.5, weight: .medium))
+                                .font(.system(size: 9.5, weight: .medium))
                         }
                         .foregroundStyle(Theme.amber)
                     }
@@ -118,10 +118,10 @@ struct PRRow: View {
                         Text("·").foregroundStyle(Theme.faint.opacity(0.9))
                         HStack(spacing: 4) {
                             Text("+\(m.additions)")
-                                .font(.system(size: 10.5, weight: .medium).monospacedDigit())
+                                .font(.system(size: 9.5, weight: .medium).monospacedDigit())
                                 .foregroundStyle(Theme.green)
                             Text("-\(m.deletions)")
-                                .font(.system(size: 10.5, weight: .medium).monospacedDigit())
+                                .font(.system(size: 9.5, weight: .medium).monospacedDigit())
                                 .foregroundStyle(Color(red: 0.92, green: 0.35, blue: 0.45))
                         }
                     }
@@ -130,7 +130,7 @@ struct PRRow: View {
                         Text("·").foregroundStyle(Theme.faint.opacity(0.9))
                         HStack(spacing: 3) {
                             LucideRepoIconView(icon: .messageSquareDiff, size: 11, color: .secondary)
-                            Text("\(pr.comments)").font(.system(size: 10.5))
+                            Text("\(pr.comments)").font(.system(size: 9.5))
                         }
                         .foregroundStyle(.secondary)
                     }
@@ -138,7 +138,7 @@ struct PRRow: View {
                     Spacer(minLength: 4)
 
                     Text(RelativeTime.short(pr.updated))
-                        .font(.system(size: 10.5))
+                        .font(.system(size: 9.5))
                         .foregroundStyle(Theme.meta)
                 }
             }
@@ -179,7 +179,7 @@ struct PRRow: View {
                 LucideRepoIconView(icon: .circleDotDashed, size: 11, color: reviewLineColor)
             }
             Text(reviewLineLabel)
-                .font(.system(size: 10.5, weight: .medium))
+                .font(.system(size: 9.5, weight: .medium))
                 .foregroundStyle(reviewLineColor)
         }
     }
@@ -227,7 +227,7 @@ struct IssueRow: View {
                 HStack(spacing: 8) {
                     IconDot(color: Theme.green)
                     Text(issue.title)
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.system(size: 11.5, weight: .medium))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
                     Spacer(minLength: 4)
@@ -247,12 +247,12 @@ struct IssueRow: View {
                     if issue.comments > 0 {
                         HStack(spacing: 3) {
                             LucideRepoIconView(icon: .messageSquareDiff, size: 11, color: .secondary)
-                            Text("\(issue.comments)").font(.system(size: 10.5))
+                            Text("\(issue.comments)").font(.system(size: 9.5))
                         }
                         .foregroundStyle(.secondary)
                     }
                     Text(RelativeTime.short(issue.updated))
-                        .font(.system(size: 10.5))
+                        .font(.system(size: 9.5))
                         .foregroundStyle(Theme.meta)
                 }
             }

--- a/Sources/Gitbar/Views/SectionEditorView.swift
+++ b/Sources/Gitbar/Views/SectionEditorView.swift
@@ -1,0 +1,741 @@
+import SwiftUI
+
+enum SectionEditorMode: Equatable {
+    case create(PanelTab)
+    case edit(GitbarSection)
+
+    var tab: PanelTab {
+        switch self {
+        case .create(let t): return t
+        case .edit(let s): return s.tab
+        }
+    }
+
+    var section: GitbarSection? {
+        switch self {
+        case .create: return nil
+        case .edit(let s): return s
+        }
+    }
+}
+
+struct SectionEditorView: View {
+    let mode: SectionEditorMode
+    let onSave: (GitbarSection) -> Void
+    let onDelete: (() -> Void)?
+    let onCancel: () -> Void
+
+    @State private var showDeleteConfirm = false
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var name: String
+    @State private var icon: String?
+    @State private var visibility: SectionVisibility
+    @State private var contributesToBadge: Bool
+    @State private var filters: [FilterDraft]
+    @State private var requestEmojiPicker: Bool = false
+
+    private let contentHorizontalPadding: CGFloat = 16
+    private let conditionFieldWidth: CGFloat = 132
+    private let operatorWidth: CGFloat = 64
+    private let conditionValueWidth: CGFloat = 160
+    init(
+        mode: SectionEditorMode,
+        onSave: @escaping (GitbarSection) -> Void,
+        onDelete: (() -> Void)? = nil,
+        onCancel: @escaping () -> Void
+    ) {
+        self.mode = mode
+        self.onSave = onSave
+        self.onDelete = onDelete
+        self.onCancel = onCancel
+
+        switch mode {
+        case .create:
+            _name = State(initialValue: "")
+            _icon = State(initialValue: nil)
+            _visibility = State(initialValue: .visible)
+            _contributesToBadge = State(initialValue: false)
+            _filters = State(initialValue: [FilterDraft(defaultCondition: Self.defaultCondition(for: mode.tab))])
+        case .edit(let section):
+            _name = State(initialValue: section.name)
+            _icon = State(initialValue: section.icon)
+            _visibility = State(initialValue: section.visibility)
+            _contributesToBadge = State(initialValue: section.contributesToBadge)
+            let existing = section.filters.map { FilterDraft(from: $0, tab: mode.tab) }
+            _filters = State(initialValue: existing.isEmpty ? [FilterDraft()] : existing)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(Theme.hairline(colorScheme))
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    nameSection
+                    repositoriesSection
+                    filtersSection
+                    visibilitySection
+                    badgeSection
+                }
+                .padding(.horizontal, contentHorizontalPadding)
+                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .alert("Delete filter?", isPresented: $showDeleteConfirm) {
+                Button("Delete", role: .destructive) { onDelete?() }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("\"\(name)\" will be removed. This can't be undone.")
+            }
+            .frame(maxWidth: .infinity)
+            Divider().overlay(Theme.hairline(colorScheme))
+            footer
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Button {
+                onCancel()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Back")
+
+            Text(mode.section == nil ? "Create filter" : "Update \"\(name)\"")
+                .font(.system(size: 13, weight: .semibold))
+            Text("· \(mode.tab.label)")
+                .font(.system(size: 11.5))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel("Section name")
+            HStack(spacing: 6) {
+                ZStack {
+                    EmojiCaptureField(selected: $icon, requestFocus: $requestEmojiPicker)
+                        .frame(width: 1, height: 1)
+                        .opacity(0.01)
+                        .allowsHitTesting(false)
+
+                    Button {
+                        requestEmojiPicker = true
+                    } label: {
+                        Group {
+                            if let icon, !icon.isEmpty {
+                                Text(icon).font(.system(size: 16))
+                            } else {
+                                Image(systemName: "face.smiling")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundStyle(Theme.meta)
+                            }
+                        }
+                        .frame(width: 28, height: 22)
+                        .background(Theme.surfaceHi(colorScheme), in: RoundedRectangle(cornerRadius: 5))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .help("Pick emoji (⌃⌘Space works too)")
+                    .contextMenu {
+                        if icon != nil {
+                            Button("Remove icon") { icon = nil }
+                        }
+                    }
+                }
+                .fixedSize()
+
+                TextField("e.g. Assigned to me", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var repositoriesSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel("Repositories")
+            HStack {
+                Text("Default repos")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("Coming soon")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Theme.meta)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Theme.surfaceHi(colorScheme), in: Capsule())
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Theme.surfaceHi(colorScheme).opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6).stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
+            )
+        }
+    }
+
+    private var filtersSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            fieldLabel("Filters")
+            Text("Rows inside a filter are ANDed; filters are ORed.")
+                .font(.system(size: 10.5))
+                .foregroundStyle(Theme.meta)
+
+            VStack(spacing: 8) {
+                ForEach(Array(filters.enumerated()), id: \.element.id) { filterIndex, filter in
+                    filterGroup(filterIndex: filterIndex, filter: filter)
+                    if filterIndex < filters.count - 1 {
+                        Text("OR")
+                            .font(.system(size: 9.5, weight: .semibold))
+                            .foregroundStyle(Theme.meta)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, 2)
+                    }
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    filters.append(FilterDraft())
+                } label: {
+                    Label("Add filter", systemImage: "plus")
+                        .font(.system(size: 11.5))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Theme.blue)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Theme.blue.opacity(0.12), in: Capsule())
+
+                Spacer()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func filterGroup(filterIndex: Int, filter: FilterDraft) -> some View {
+        VStack(spacing: 6) {
+            ForEach(Array(filter.conditions.enumerated()), id: \.element.id) { conditionIndex, _ in
+                conditionRow(filterIndex: filterIndex, conditionIndex: conditionIndex, isFirstInFilter: conditionIndex == 0)
+            }
+            HStack {
+                Button {
+                    filters[filterIndex].conditions.append(ConditionDraft())
+                } label: {
+                    Label("Add condition", systemImage: "plus")
+                        .font(.system(size: 11.5))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Theme.blue)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Theme.blue.opacity(0.12), in: Capsule())
+
+                if filters.count > 1 {
+                    Button {
+                        filters.remove(at: filterIndex)
+                    } label: {
+                        Text("Remove filter")
+                            .font(.system(size: 11.5))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.top, 2)
+        }
+        .padding(8)
+        .background(Theme.surfaceHi(colorScheme).opacity(0.2), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8).stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
+        )
+    }
+
+    private var visibilitySection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel("Visibility")
+            Picker("", selection: $visibility) {
+                Text("Visible").tag(SectionVisibility.visible)
+                Text("Collapsed by default").tag(SectionVisibility.collapsedByDefault)
+                Text("Hidden").tag(SectionVisibility.hidden)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .controlSize(.small)
+            .frame(maxWidth: 260, alignment: .leading)
+            Text(visibilityHint)
+                .font(.system(size: 10.5))
+                .foregroundStyle(Theme.meta)
+        }
+    }
+
+    private var badgeSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel("Badge count")
+            Toggle(isOn: $contributesToBadge) {
+                Text("Items in this section add to the inbox badge count")
+                    .font(.system(size: 11.5))
+            }
+            .toggleStyle(.checkbox)
+        }
+    }
+
+    @ViewBuilder
+    private func conditionRow(filterIndex: Int, conditionIndex: Int, isFirstInFilter: Bool) -> some View {
+        let binding = conditionBinding(filterIndex: filterIndex, conditionIndex: conditionIndex)
+        HStack(spacing: 8) {
+            Text(isFirstInFilter ? "Where" : "And")
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 42, alignment: .trailing)
+
+            Picker("", selection: binding.field) {
+                ForEach(Self.availableFields(for: mode.tab)) { field in
+                    Text(field.label(for: mode.tab)).tag(field)
+                }
+            }
+            .labelsHidden()
+            .controlSize(.small)
+            .frame(width: conditionFieldWidth)
+
+            operatorPicker(for: binding)
+            valueEditor(for: binding)
+                .frame(width: conditionValueWidth, alignment: .leading)
+
+            Button {
+                if filters[filterIndex].conditions.count > 1 {
+                    filters[filterIndex].conditions.remove(at: conditionIndex)
+                }
+            } label: {
+                Image(systemName: "minus.circle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(filters[filterIndex].conditions.count > 1 ? Color.secondary : Color.secondary.opacity(0.3))
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .disabled(filters[filterIndex].conditions.count <= 1)
+            .help(filters[filterIndex].conditions.count > 1 ? "Remove condition" : "At least one condition is required")
+        }
+        .padding(.leading, 8)
+        .padding(.trailing, 12)
+        .padding(.vertical, 6)
+        .background(Theme.surfaceHi(colorScheme).opacity(0.28), in: RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6).stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
+        )
+    }
+
+    private func conditionBinding(filterIndex: Int, conditionIndex: Int) -> Binding<ConditionDraft> {
+        Binding(
+            get: { filters[filterIndex].conditions[conditionIndex] },
+            set: { filters[filterIndex].conditions[conditionIndex] = $0 }
+        )
+    }
+
+    @ViewBuilder
+    private func operatorPicker(for binding: Binding<ConditionDraft>) -> some View {
+        switch binding.wrappedValue.field {
+        case .prStatus, .ciStatus, .reviewer, .assignee, .repository, .label:
+            Picker("", selection: binding.setOp) {
+                Text("is").tag(SectionSetOp.includes)
+                Text("is not").tag(SectionSetOp.excludes)
+            }
+            .labelsHidden()
+            .controlSize(.small)
+            .frame(width: operatorWidth)
+        case .author:
+            Picker("", selection: binding.eqOp) {
+                Text("is").tag(SectionEqOp.is_)
+                Text("is not").tag(SectionEqOp.isNot)
+            }
+            .labelsHidden()
+            .controlSize(.small)
+            .frame(width: operatorWidth)
+        case .draft, .mergeConflict:
+            Text("is")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .frame(width: operatorWidth, alignment: .center)
+        }
+    }
+
+    @ViewBuilder
+    private func valueEditor(for binding: Binding<ConditionDraft>) -> some View {
+        switch binding.wrappedValue.field {
+        case .prStatus:
+            multiSelectMenu(
+                title: summary(
+                    for: binding.wrappedValue.prStatuses.map(\.rawValue),
+                    placeholder: "Select status"
+                ),
+                all: SectionPRStatusValue.allCases.filter { $0 != .merging }.map { ($0, $0.rawValue) },
+                selection: binding.prStatuses
+            )
+        case .ciStatus:
+            multiSelectMenu(
+                title: summary(
+                    for: binding.wrappedValue.ciStatuses.map { $0.rawValue.capitalized },
+                    placeholder: "Select CI"
+                ),
+                all: CIPillKind.allCases.map { ($0, $0.rawValue.capitalized) },
+                selection: binding.ciStatuses
+            )
+        case .author:
+            TextField("login", text: binding.authorLogin)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        case .reviewer:
+            TextField("login", text: binding.reviewerLogin)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        case .assignee:
+            TextField("login", text: binding.assigneeLogin)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        case .repository:
+            TextField("owner/repo, owner/repo", text: binding.repositoryText)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        case .label:
+            TextField("label name", text: binding.labelName)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        case .draft:
+            Picker("", selection: binding.isDraftValue) {
+                Text("a draft").tag(true)
+                Text("not a draft").tag(false)
+            }
+            .labelsHidden()
+            .controlSize(.small)
+            .frame(width: 130)
+        case .mergeConflict:
+            Picker("", selection: binding.hasMergeConflictValue) {
+                Text("conflicting").tag(true)
+                Text("not conflicting").tag(false)
+            }
+            .labelsHidden()
+            .controlSize(.small)
+            .frame(width: 150)
+        }
+    }
+
+    private func multiSelectMenu<T: Hashable>(
+        title: String,
+        all: [(T, String)],
+        selection: Binding<Set<T>>
+    ) -> some View {
+        Menu {
+            ForEach(all, id: \.0) { (value, label) in
+                Button {
+                    if selection.wrappedValue.contains(value) {
+                        selection.wrappedValue.remove(value)
+                    } else {
+                        selection.wrappedValue.insert(value)
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: selection.wrappedValue.contains(value) ? "checkmark.square.fill" : "square")
+                        Text(label)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(title)
+                    .font(.system(size: 11.5))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(minWidth: 140, alignment: .leading)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Theme.surfaceHi(colorScheme), in: RoundedRectangle(cornerRadius: 5))
+        .overlay(
+            RoundedRectangle(cornerRadius: 5).stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
+        )
+    }
+
+    private func summary(for items: [String], placeholder: String) -> String {
+        guard !items.isEmpty else { return placeholder }
+        if items.count <= 2 { return items.joined(separator: ", ") }
+        return "\(items.count) selected"
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            if canDelete {
+                Button(role: .destructive) {
+                    showDeleteConfirm = true
+                } label: {
+                    Text("Delete")
+                        .font(.system(size: 11.5))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.red.opacity(0.9))
+            }
+            Spacer()
+            Button("Cancel") { onCancel() }
+                .controlSize(.small)
+            Button("Save") { attemptSave() }
+                .controlSize(.small)
+                .buttonStyle(.borderedProminent)
+                .disabled(!canSave)
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(.horizontal, contentHorizontalPadding)
+        .padding(.vertical, 8)
+    }
+
+    private var canDelete: Bool {
+        onDelete != nil && (mode.section?.isDefault == false)
+    }
+
+    private var canSave: Bool {
+        let parsed = filters.map { draft in
+            draft.conditions.compactMap { $0.toCondition() }
+        }
+        let hasInvalid = parsed.contains { $0.isEmpty } || parsed.count != filters.count
+        let mismatchedCounts = zip(parsed, filters).contains { $0.count != $1.conditions.count }
+        return !name.trimmingCharacters(in: .whitespaces).isEmpty
+            && !filters.isEmpty
+            && !hasInvalid
+            && !mismatchedCounts
+    }
+
+    private func attemptSave() {
+        let parsedFilters = filters.compactMap { draft -> SectionFilter? in
+            let conditions = draft.conditions.compactMap { $0.toCondition() }
+            guard !conditions.isEmpty, conditions.count == draft.conditions.count else { return nil }
+            return SectionFilter(conditions: conditions)
+        }
+        guard parsedFilters.count == filters.count else { return }
+
+        switch mode {
+        case .create(let tab):
+            let created = GitbarSection(
+                id: UUID(),
+                name: name.trimmingCharacters(in: .whitespaces),
+                icon: icon,
+                tab: tab,
+                repos: .defaults,
+                filters: parsedFilters,
+                visibility: visibility,
+                contributesToBadge: contributesToBadge,
+                sort: .updatedDesc,
+                collapsed: visibility == .collapsedByDefault,
+                order: 0
+            )
+            onSave(created)
+        case .edit(let section):
+            var updated = section
+            updated.name = name.trimmingCharacters(in: .whitespaces)
+            updated.icon = icon
+            updated.filters = parsedFilters
+            updated.visibility = visibility
+            updated.contributesToBadge = contributesToBadge
+            onSave(updated)
+        }
+    }
+
+    private func fieldLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.primary.opacity(0.8))
+    }
+
+    fileprivate static func defaultCondition(for tab: PanelTab) -> ConditionDraft {
+        switch tab {
+        case .issues:
+            var draft = ConditionDraft()
+            draft.field = .assignee
+            return draft
+        case .mine, .review, .all, .stats:
+            return ConditionDraft()
+        }
+    }
+
+    fileprivate static func availableFields(for tab: PanelTab) -> [ConditionDraft.Field] {
+        switch tab {
+        case .issues:
+            return [.prStatus, .author, .assignee, .repository, .label]
+        case .mine, .review:
+            return [.prStatus, .author, .assignee, .repository, .label, .ciStatus, .draft]
+        case .all, .stats:
+            return [.prStatus, .author, .repository, .label]
+        }
+    }
+
+    private var visibilityHint: String {
+        switch visibility {
+        case .visible: return "Section shows expanded in the tab."
+        case .collapsedByDefault: return "Section shows collapsed until you expand it."
+        case .hidden: return "Section doesn't render. Still counts toward the badge if enabled."
+        }
+    }
+}
+
+struct FilterDraft: Identifiable, Equatable {
+    var id: UUID = UUID()
+    var conditions: [ConditionDraft] = [ConditionDraft()]
+
+    init() {}
+
+    init(defaultCondition: ConditionDraft) {
+        conditions = [defaultCondition]
+    }
+
+    init(from filter: SectionFilter, tab: PanelTab) {
+        let allowed = Set(SectionEditorView.availableFields(for: tab))
+        let existing = filter.conditions.map(ConditionDraft.init(from:)).map { draft in
+            var normalized = draft
+            if !allowed.contains(normalized.field) {
+                normalized.field = SectionEditorView.defaultCondition(for: tab).field
+            }
+            return normalized
+        }
+        conditions = existing.isEmpty ? [ConditionDraft()] : existing
+    }
+}
+
+struct ConditionDraft: Identifiable, Equatable {
+    var id: UUID = UUID()
+    var field: Field = .prStatus
+    var setOp: SectionSetOp = .includes
+    var eqOp: SectionEqOp = .is_
+    var prStatuses: Set<SectionPRStatusValue> = [.open]
+    var ciStatuses: Set<CIPillKind> = [.fail]
+    var authorLogin: String = ""
+    var reviewerLogin: String = ""
+    var assigneeLogin: String = ""
+    var repositoryText: String = ""
+    var labelName: String = ""
+    var isDraftValue: Bool = true
+    var hasMergeConflictValue: Bool = true
+
+    enum Field: String, CaseIterable, Identifiable, Hashable {
+        case prStatus, author, reviewer, assignee, repository, label, ciStatus, draft, mergeConflict
+
+        var id: String { rawValue }
+        func label(for tab: PanelTab) -> String {
+            switch self {
+            case .prStatus: return tab == .issues ? "Issue status" : "PR status"
+            case .author: return "Author"
+            case .reviewer: return "Direct reviewer"
+            case .assignee: return "Assignee"
+            case .repository: return "Repository"
+            case .label: return "Label"
+            case .ciStatus: return "CI status"
+            case .draft: return "Draft"
+            case .mergeConflict: return "Merge conflict"
+            }
+        }
+    }
+
+    init() {}
+
+    init(from condition: SectionCondition) {
+        switch condition {
+        case .prStatus(let op, let values):
+            field = .prStatus
+            setOp = op
+            prStatuses = Set(values)
+        case .author(let op, let login):
+            field = .author
+            eqOp = op
+            authorLogin = login
+        case .reviewer:
+            // Legacy: this condition can't be evaluated reliably; fall back to PR status.
+            field = .prStatus
+        case .ciStatus(let op, let values):
+            field = .ciStatus
+            setOp = op
+            ciStatuses = Set(values)
+        case .draft(let isDraft):
+            field = .draft
+            isDraftValue = isDraft
+        case .label(let op, let name):
+            field = .label
+            setOp = op
+            labelName = name
+        case .assignee(let op, let login):
+            field = .assignee
+            setOp = op
+            assigneeLogin = login
+        case .repository(let op, let repos):
+            field = .repository
+            setOp = op
+            repositoryText = repos.joined(separator: ", ")
+        case .hasMergeConflict(let isOn):
+            field = .mergeConflict
+            hasMergeConflictValue = isOn
+        }
+    }
+
+    func toCondition() -> SectionCondition? {
+        switch field {
+        case .prStatus:
+            guard !prStatuses.isEmpty else { return nil }
+            return .prStatus(op: setOp, values: Array(prStatuses))
+        case .author:
+            let trimmed = authorLogin.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            return .author(op: eqOp, login: trimmed)
+        case .reviewer:
+            let trimmed = reviewerLogin.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            return .reviewer(op: setOp, login: trimmed)
+        case .ciStatus:
+            guard !ciStatuses.isEmpty else { return nil }
+            return .ciStatus(op: setOp, values: Array(ciStatuses))
+        case .draft:
+            return .draft(is: isDraftValue)
+        case .label:
+            let trimmed = labelName.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            return .label(op: setOp, name: trimmed)
+        case .assignee:
+            let trimmed = assigneeLogin.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            return .assignee(op: setOp, login: trimmed)
+        case .repository:
+            let repos = repositoryText
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            guard !repos.isEmpty else { return nil }
+            return .repository(op: setOp, repos: repos)
+        case .mergeConflict:
+            return .hasMergeConflict(is: hasMergeConflictValue)
+        }
+    }
+}

--- a/Sources/Gitbar/Views/SectionsManagerView.swift
+++ b/Sources/Gitbar/Views/SectionsManagerView.swift
@@ -1,0 +1,302 @@
+import SwiftUI
+
+struct SectionsManagerView: View {
+    let onCreate: (PanelTab) -> Void
+    let onEdit: (GitbarSection) -> Void
+    let onBack: () -> Void
+
+    @EnvironmentObject var store: Store
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var dropTargetID: UUID?
+    @State private var dropAppendTab: PanelTab?
+    @State private var pendingDelete: GitbarSection?
+
+    private let tabs: [PanelTab] = [.mine, .review, .issues]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(Theme.hairline(colorScheme))
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    ForEach(tabs) { tab in
+                        tabGroup(for: tab)
+                    }
+                    Color.clear.frame(height: 6)
+                }
+                .padding(14)
+            }
+        }
+        .alert("Delete filter?", isPresented: deleteAlertBinding, presenting: pendingDelete) { section in
+            Button("Delete", role: .destructive) {
+                store.deleteSection(id: section.id, tab: section.tab)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { section in
+            Text("\"\(section.name)\" will be removed. This can't be undone.")
+        }
+    }
+
+    private var deleteAlertBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { if !$0 { pendingDelete = nil } }
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help("Back")
+
+            Text("Manage sections")
+                .font(.system(size: 13, weight: .semibold))
+            Text("Create and edit filters by tab")
+                .font(.system(size: 11))
+                .foregroundStyle(Theme.meta)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func tabGroup(for tab: PanelTab) -> some View {
+        let sections = store.sections(for: tab)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(tab.label.uppercased())
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .tracking(0.6)
+                    .foregroundStyle(Theme.meta)
+                Text("\(sections.count)")
+                    .font(.system(size: 9.5, weight: .semibold))
+                    .foregroundStyle(Theme.meta)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Theme.surfaceHi(colorScheme), in: Capsule())
+                Spacer()
+                Button {
+                    onCreate(tab)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Add")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(Theme.blue)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Theme.blue.opacity(0.12), in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .help("New section in \(tab.label)")
+            }
+            if sections.isEmpty {
+                emptyRow(tab: tab)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(sections.enumerated()), id: \.element.id) { index, section in
+                        row(section)
+                        if index < sections.count - 1 {
+                            Divider().overlay(Theme.hairline(colorScheme))
+                        }
+                    }
+                    appendDropZone(tab: tab)
+                }
+                .background(Theme.surfaceHi(colorScheme).opacity(0.35))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func appendDropZone(tab: PanelTab) -> some View {
+        let targeted = dropAppendTab == tab
+        Rectangle()
+            .fill(targeted ? Theme.blue.opacity(0.15) : Color.clear)
+            .frame(height: targeted ? 10 : 4)
+            .overlay(alignment: .top) {
+                if targeted {
+                    Rectangle().fill(Theme.blue).frame(height: 2)
+                }
+            }
+            .dropDestination(for: String.self) { items, _ in
+                guard let str = items.first,
+                      let id = UUID(uuidString: str) else { return false }
+                store.reorderSection(in: tab, moving: id, before: nil)
+                return true
+            } isTargeted: { isIn in
+                if isIn { dropAppendTab = tab }
+                else if dropAppendTab == tab { dropAppendTab = nil }
+            }
+    }
+
+    @ViewBuilder
+    private func row(_ section: GitbarSection) -> some View {
+        let isTarget = dropTargetID == section.id
+        HStack(spacing: 10) {
+            Image(systemName: "line.3.horizontal")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(Theme.meta.opacity(0.7))
+                .frame(width: 12)
+            if let icon = section.icon, !icon.isEmpty {
+                Text(icon)
+                    .font(.system(size: 14))
+                    .frame(width: 18)
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(section.name)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.primary)
+                Text(summary(for: section))
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.meta)
+            }
+            Spacer(minLength: 8)
+            if section.isDefault {
+                pill("Default", color: Theme.blue)
+            }
+            if section.contributesToBadge {
+                pill("Badge", color: Theme.amber)
+            }
+            visibilityMenu(for: section)
+            Menu {
+                Button("Edit…") { onEdit(section) }
+                if !section.isDefault {
+                    Divider()
+                    Button("Delete", role: .destructive) {
+                        pendingDelete = section
+                    }
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Theme.faint)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .overlay(alignment: .top) {
+            if isTarget {
+                Rectangle().fill(Theme.blue).frame(height: 2)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onEdit(section) }
+        .draggable(section.id.uuidString)
+        .dropDestination(for: String.self) { items, _ in
+            guard let str = items.first,
+                  let id = UUID(uuidString: str),
+                  id != section.id else { return false }
+            store.reorderSection(in: section.tab, moving: id, before: section.id)
+            return true
+        } isTargeted: { isIn in
+            if isIn { dropTargetID = section.id }
+            else if dropTargetID == section.id { dropTargetID = nil }
+        }
+    }
+
+    @ViewBuilder
+    private func visibilityMenu(for section: GitbarSection) -> some View {
+        Menu {
+            ForEach(SectionVisibility.allCases, id: \.self) { option in
+                Button {
+                    updateVisibility(for: section, to: option)
+                } label: {
+                    if section.visibility == option {
+                        Label(visibilityLabel(option), systemImage: "checkmark")
+                    } else {
+                        Text(visibilityLabel(option))
+                    }
+                }
+            }
+        } label: {
+            pill(visibilityLabel(section.visibility), color: .secondary)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    private func updateVisibility(for section: GitbarSection, to visibility: SectionVisibility) {
+        guard section.visibility != visibility else { return }
+        var updated = section
+        updated.visibility = visibility
+        switch visibility {
+        case .visible: updated.collapsed = false
+        case .collapsedByDefault: updated.collapsed = true
+        case .hidden: break
+        }
+        store.updateSection(updated)
+    }
+
+    private func pill(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.system(size: 9.5, weight: .semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.14), in: Capsule())
+    }
+
+    private func emptyRow(tab: PanelTab) -> some View {
+        Button {
+            onCreate(tab)
+        } label: {
+            HStack {
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.meta)
+                Text("No sections yet - create one")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.meta)
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 10)
+        .background(Theme.surfaceHi(colorScheme).opacity(0.25), in: RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(Theme.hairline(colorScheme), style: StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+        )
+        .buttonStyle(.plain)
+    }
+
+    private func summary(for section: GitbarSection) -> String {
+        let count = section.filters.first?.conditions.count ?? 0
+        switch count {
+        case 0: return "No conditions"
+        case 1: return "1 condition"
+        default: return "\(count) conditions"
+        }
+    }
+
+    private func visibilityLabel(_ v: SectionVisibility) -> String {
+        switch v {
+        case .visible: return "Visible"
+        case .collapsedByDefault: return "Collapsed"
+        case .hidden: return "Hidden"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds user-defined **filter sections**: named groups of conditions users can create to slice the Mine / Review / Issues tabs. Supersedes #2 (which was a closed preset list). Design doc: `docs/sections.md`.

## Highlights

- **Data model** (`GitbarSection`) — name, optional icon, tab, filters (ANDed conditions within, ORed across filters), visibility, badge opt-in, sort, order, `isDefault` flag. Stored in `~/.gitbar/config.json` alongside the existing token; seeded defaults migrated in on first run.
- **Editor** (`SectionEditorView`) — name + icon, multi-condition builder, multi-filter OR, visibility picker, badge toggle. Inline overlay (not a sheet) because menu-bar popovers and sheets fight each other.
- **Manager** (`SectionsManagerView`) — grouped by tab, drag-to-reorder via `.draggable` / `.dropDestination`, per-row visibility menu, Default pill, Delete gated to non-defaults (with confirm alert).
- **Entry points** — tab-bar `+` opens a menu: *View filters* → manager, *Add new filter in [current tab]* → editor in create mode. Tab bar and footer hide while either overlay is active.
- **Condition catalog** — PR status, author, assignee, repository, label, CI status, draft, merge conflict. `Direct reviewer` removed (the Search API doesn't return `requested_reviewers`).
- **Emoji icon** — Slack-style button glued to the left of the name field. Primary click opens the **native macOS character palette** via `NSApp.orderFrontCharacterPalette`; an invisible `NSTextField` captures the selection and extracts the first emoji grapheme. Right-click menu offers a curated quick-pick fallback.
- **Popover dismissal fix** — `EmojiPaletteState.isOpen` flag suppresses the global click-outside monitor while the character palette is open, so picking an emoji no longer closes the menu-bar panel.
- **Matcher correctness** — `issueStatus` now uses `pullRequest?.mergedAt` to distinguish merged / closed / open (previously `.merged` was unreachable and `.merging` was mis-labeled as "approved open"). Empty conditions return `false` instead of matching everything. Legacy `.reviewer` filters return `false` and get normalized to `.prStatus` when re-edited.
- **Badge count** — now driven by sections with `contributesToBadge = true`, de-duplicated by row id. Falls back to legacy `myPRs + reviewRequests + issues` count when no section opts in.
- **Row density** — title 12.5 → 11.5, metadata 10.5 → 9.5 across PR and Issue rows.

## Explicitly out of scope

- **Repo picker** — "Default repos" row is disabled with a "Coming soon" pill. v1 uses the token's implicit scope.
- **Requested-reviewers condition** — needs per-PR GraphQL fetches; revisit alongside a Review-status condition (Approved / Changes requested / Pending).
- **Cross-tab dragging** — filter semantics don't translate cleanly between tabs; within-tab reordering only.
- **Share filters** — button placeholder in the editor footer, not wired.

## Test plan

- [ ] Fresh install: seeded defaults appear on Mine / Review / Issues with the **Default** pill; they cannot be deleted.
- [ ] Create a new section via tab-bar `+` → *Add new filter* → fill name, pick emoji via native picker, add at least one condition, save. Section renders in the correct tab.
- [ ] Emoji picker: click icon button → native palette opens; pick an emoji → panel stays open, icon updates, section header and manager row show the emoji.
- [ ] Manager: drag-reorder within a tab persists across restart; append-drop zone at group bottom works.
- [ ] Visibility pill menu: switching *Visible* / *Collapsed by default* / *Hidden* updates the tab immediately.
- [ ] Badge: enable on a section with matching rows, verify menu-bar badge count reflects it; disable on all sections, verify fallback count.
- [ ] Delete flow: non-defaults show Delete in editor footer + manager menu with confirm alert; defaults show neither.
- [ ] Matcher: PR-status *Merged* matches merged PRs; *Closed* matches closed-unmerged PRs; *Open* matches open PRs.
- [ ] Legacy config: a `.reviewer` condition in config.json doesn't crash the editor (falls back to PR status on open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)