### PR TITLE
Fix menu bar count + polish UI

### DIFF
--- a/Sources/Gitbar/App.swift
+++ b/Sources/Gitbar/App.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         configureStatusButton()
         setupPanel()
+        setupMainMenu()
 
         syncAppearance()
         appearanceObservation = NSApp.observe(\.effectiveAppearance, options: [.new]) { [weak self] _, _ in
@@ -105,6 +106,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         default:
             return event
         }
+    }
+
+    /// LSUIElement apps don't show a menu bar, but an NSMainMenu is still required
+    /// for ⌘V / ⌘C / ⌘X / ⌘A to dispatch to the first responder (NSTextField etc.).
+    private func setupMainMenu() {
+        let mainMenu = NSMenu()
+
+        let editItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        let redo = NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+        redo.keyEquivalentModifierMask = [.command, .shift]
+        editMenu.addItem(redo)
+        editMenu.addItem(.separator())
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSResponder.selectAll(_:)), keyEquivalent: "a")
+        editItem.submenu = editMenu
+        mainMenu.addItem(editItem)
+
+        NSApp.mainMenu = mainMenu
     }
 
     private func setupPanel() {

--- a/Sources/Gitbar/Store.swift
+++ b/Sources/Gitbar/Store.swift
@@ -60,39 +60,7 @@ final class Store: ObservableObject {
     }
 
     var badgeCount: Int {
-        let badgedSections = sectionsByTab.values
-            .flatMap { $0 }
-            .filter { $0.contributesToBadge }
-        guard !badgedSections.isEmpty else {
-            return myPRs.count + reviewRequests.count + issues.count
-        }
-
-        var ids = Set<Int>()
-        for section in badgedSections {
-            let source: [GHIssue]
-            switch section.tab {
-            case .mine:
-                source = myPRs
-            case .review:
-                source = reviewRequests
-            case .issues:
-                source = issues
-            case .all, .stats:
-                source = []
-            }
-            for row in source {
-                if SectionMatcher.matches(
-                    section: section,
-                    row: row,
-                    viewerLogin: myLogin,
-                    metadata: prRowMetadata[row.id],
-                    reviewState: myPRReviewState[row.id]
-                ) {
-                    ids.insert(row.id)
-                }
-            }
-        }
-        return ids.count
+        myPRs.count + reviewRequests.count + issues.count
     }
 
     func refresh() {

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -136,15 +136,17 @@ struct PanelView: View {
         "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))"
     }
 
+    private let allTabPreviewLimit = 5
+
     private var navigableItems: [PanelListEntry] {
         switch tab {
         case .stats:
             return []
         case .all:
             var rows: [PanelListEntry] = []
-            rows.append(contentsOf: store.myPRs.map { PanelListEntry(id: "all-m-\($0.id)", htmlURL: $0.htmlUrl) })
-            rows.append(contentsOf: store.reviewRequests.map { PanelListEntry(id: "all-r-\($0.id)", htmlURL: $0.htmlUrl) })
-            rows.append(contentsOf: store.issues.map { PanelListEntry(id: "all-i-\($0.id)", htmlURL: $0.htmlUrl) })
+            rows.append(contentsOf: store.myPRs.prefix(allTabPreviewLimit).map { PanelListEntry(id: "all-m-\($0.id)", htmlURL: $0.htmlUrl) })
+            rows.append(contentsOf: store.reviewRequests.prefix(allTabPreviewLimit).map { PanelListEntry(id: "all-r-\($0.id)", htmlURL: $0.htmlUrl) })
+            rows.append(contentsOf: store.issues.prefix(allTabPreviewLimit).map { PanelListEntry(id: "all-i-\($0.id)", htmlURL: $0.htmlUrl) })
             return rows
         case .mine:
             return sectionEntries(for: .mine, sourceRows: store.myPRs)
@@ -428,7 +430,7 @@ struct PanelView: View {
                                 count: store.myPRs.count,
                                 accent: .secondary
                             )
-                            ForEach(store.myPRs) { pr in
+                            ForEach(Array(store.myPRs.prefix(allTabPreviewLimit))) { pr in
                                 PRRow(
                                     pr: pr,
                                     showAuthor: false,
@@ -438,6 +440,9 @@ struct PanelView: View {
                                 )
                                 .id("all-m-\(pr.id)")
                             }
+                            if store.myPRs.count > allTabPreviewLimit {
+                                viewAllButton(destination: .mine, remaining: store.myPRs.count - allTabPreviewLimit)
+                            }
                         }
                         if tab == .all, showReview, !store.reviewRequests.isEmpty {
                             SectionHeader(
@@ -446,7 +451,7 @@ struct PanelView: View {
                                 count: store.reviewRequests.count,
                                 accent: Theme.amber
                             )
-                            ForEach(store.reviewRequests) { pr in
+                            ForEach(Array(store.reviewRequests.prefix(allTabPreviewLimit))) { pr in
                                 PRRow(
                                     pr: pr,
                                     showAuthor: true,
@@ -454,6 +459,9 @@ struct PanelView: View {
                                     isSelected: isEntrySelected("all-r-\(pr.id)")
                                 )
                                 .id("all-r-\(pr.id)")
+                            }
+                            if store.reviewRequests.count > allTabPreviewLimit {
+                                viewAllButton(destination: .review, remaining: store.reviewRequests.count - allTabPreviewLimit)
                             }
                         }
                         if tab == .all, showIssues, !store.issues.isEmpty {
@@ -463,9 +471,12 @@ struct PanelView: View {
                                 count: store.issues.count,
                                 accent: Theme.green
                             )
-                            ForEach(store.issues) { issue in
+                            ForEach(Array(store.issues.prefix(allTabPreviewLimit))) { issue in
                                 IssueRow(issue: issue, isSelected: isEntrySelected("all-i-\(issue.id)"))
                                     .id("all-i-\(issue.id)")
+                            }
+                            if store.issues.count > allTabPreviewLimit {
+                                viewAllButton(destination: .issues, remaining: store.issues.count - allTabPreviewLimit)
                             }
                         }
                         if tab == .mine {
@@ -572,6 +583,28 @@ struct PanelView: View {
                 .id("all-\(tab.rawValue)-\(row.id)")
             }
         }
+    }
+
+    private func viewAllButton(destination: PanelTab, remaining: Int) -> some View {
+        Button {
+            switchToTab(destination)
+        } label: {
+            HStack(spacing: 6) {
+                Text("View all \(destination.label.lowercased()) (\(remaining) more)")
+                    .font(.system(size: 10.5, weight: .medium))
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 9.5, weight: .semibold))
+            }
+            .foregroundStyle(Theme.blue)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 6)
+        .padding(.top, 2)
+        .padding(.bottom, 4)
     }
 
     private func sectionHeader(tab: PanelTab, section: GitbarSection, count: Int) -> some View {

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -616,12 +616,14 @@ struct PanelView: View {
                 .font(.system(size: 10.5, weight: .semibold))
                 .tracking(0.6)
                 .foregroundStyle(.secondary)
-            Text("\(count)")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 1)
-                .background(Theme.surfaceHi(colorScheme), in: Capsule())
+            if section.contributesToBadge {
+                Text("\(count)")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Theme.surfaceHi(colorScheme), in: Capsule())
+            }
             Spacer()
             Menu {
                 ForEach(SortChoice.allCases, id: \.rawValue) { choice in

--- a/Sources/Gitbar/Views/Rows.swift
+++ b/Sources/Gitbar/Views/Rows.swift
@@ -47,15 +47,6 @@ struct StateChip: View {
     }
 }
 
-struct IconDot: View {
-    let color: Color
-
-    var body: some View {
-        LucideRepoIconView(icon: .circleDot, size: 12, color: color)
-            .frame(width: 16, height: 16)
-    }
-}
-
 // MARK: - PR row
 
 struct PRRow: View {
@@ -73,7 +64,9 @@ struct PRRow: View {
         Button(action: openInBrowser) {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    CIPill(kind: metadata?.ci ?? .unknown)
+                    if let ci = metadata?.ci, ci != .unknown {
+                        CIPill(kind: ci)
+                    }
                     if pr.isDraft {
                         draftBadge
                     }
@@ -224,12 +217,12 @@ struct IssueRow: View {
     var body: some View {
         Button(action: openInBrowser) {
             VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 8) {
-                    IconDot(color: Theme.green)
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
                     Text(issue.title)
                         .font(.system(size: 11.5, weight: .medium))
                         .foregroundStyle(.primary)
-                        .lineLimit(1)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
                     Spacer(minLength: 4)
                     Text("#\(issue.number)")
                         .font(Theme.monoTiny)

--- a/Sources/Gitbar/Views/SectionEditorView.swift
+++ b/Sources/Gitbar/Views/SectionEditorView.swift
@@ -56,7 +56,7 @@ struct SectionEditorView: View {
             _name = State(initialValue: "")
             _icon = State(initialValue: nil)
             _visibility = State(initialValue: .visible)
-            _contributesToBadge = State(initialValue: false)
+            _contributesToBadge = State(initialValue: true)
             _filters = State(initialValue: [FilterDraft(defaultCondition: Self.defaultCondition(for: mode.tab))])
         case .edit(let section):
             _name = State(initialValue: section.name)
@@ -305,9 +305,9 @@ struct SectionEditorView: View {
 
     private var badgeSection: some View {
         VStack(alignment: .leading, spacing: 6) {
-            fieldLabel("Badge count")
+            fieldLabel("Count pill")
             Toggle(isOn: $contributesToBadge) {
-                Text("Items in this section add to the inbox badge count")
+                Text("Show a count pill on this section's header")
                     .font(.system(size: 11.5))
             }
             .toggleStyle(.checkbox)
@@ -615,7 +615,7 @@ struct SectionEditorView: View {
         switch visibility {
         case .visible: return "Section shows expanded in the tab."
         case .collapsedByDefault: return "Section shows collapsed until you expand it."
-        case .hidden: return "Section doesn't render. Still counts toward the badge if enabled."
+        case .hidden: return "Section doesn't render in the panel."
         }
     }
 }

--- a/Sources/Gitbar/Views/SectionEditorView.swift
+++ b/Sources/Gitbar/Views/SectionEditorView.swift
@@ -417,27 +417,27 @@ struct SectionEditorView: View {
                 selection: binding.ciStatuses
             )
         case .author:
-            TextField("login", text: binding.authorLogin)
+            TextField("GitHub username", text: binding.authorLogin)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
         case .reviewer:
-            TextField("login", text: binding.reviewerLogin)
+            TextField("GitHub username", text: binding.reviewerLogin)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
         case .assignee:
-            TextField("login", text: binding.assigneeLogin)
+            TextField("GitHub username", text: binding.assigneeLogin)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
         case .repository:
-            TextField("owner/repo, owner/repo", text: binding.repositoryText)
+            TextField("owner/repo (comma-separated)", text: binding.repositoryText)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
         case .label:
-            TextField("label name", text: binding.labelName)
+            TextField("e.g. bug, frontend", text: binding.labelName)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)

--- a/Sources/Gitbar/Views/SettingsView.swift
+++ b/Sources/Gitbar/Views/SettingsView.swift
@@ -57,12 +57,7 @@ struct SettingsView: View {
             }
 
             Section("Personal access token") {
-                Text("Classic (ghp_…) and fine-grained (github_pat_…) tokens both work. Grant access to every repo you care about, or All repositories.")
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                HStack(alignment: .center, spacing: 8) {
+                HStack(spacing: 6) {
                     TokenField(
                         text: $tokenField,
                         isSecure: !tokenVisible,
@@ -72,60 +67,69 @@ struct SettingsView: View {
                     .frame(maxWidth: .infinity)
                     .frame(height: 22)
 
-                    Button("Paste") {
-                        if let s = NSPasteboard.general.string(forType: .string) {
-                            tokenField = s.trimmingCharacters(in: .whitespacesAndNewlines)
-                        }
+                    Button {
+                        tokenVisible.toggle()
+                    } label: {
+                        Image(systemName: tokenVisible ? "eye.slash" : "eye")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 24, height: 22)
+                            .contentShape(Rectangle())
                     }
-                    .help("Insert token from clipboard")
+                    .buttonStyle(.plain)
+                    .help(tokenVisible ? "Hide token" : "Show token")
 
-                    Button(tokenVisible ? "Hide" : "Show") { tokenVisible.toggle() }
                     Button("Save") { store.updateToken(tokenField) }
                         .buttonStyle(.borderedProminent)
-                        .disabled(tokenField.isEmpty)
+                        .disabled(tokenField.isEmpty || tokenField == store.token)
                 }
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Required permissions")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                    Text("Classic: enable the repo scope. Fine-grained: under Repository permissions, set at least:")
-                        .font(.system(size: 11))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Required scopes")
+                        .font(.system(size: 10.5, weight: .semibold))
                         .foregroundStyle(Theme.meta)
-                    scopeRow("Pull requests", desc: "Read and write (merge your PRs)")
-                    scopeRow("Issues", desc: "Read (assigned issues)")
-                    scopeRow("Metadata", desc: "Read (required for API access)")
+                    scopeRow("Pull requests", desc: "Read and write")
+                    scopeRow("Issues", desc: "Read")
+                    scopeRow("Metadata", desc: "Read")
                 }
                 .padding(.top, 2)
 
-                tokenNotice
+                HStack(spacing: 12) {
+                    Link("Create classic token", destination: Self.newClassicTokenURL)
+                        .font(.system(size: 11.5, weight: .medium))
+                        .tint(Theme.blue)
+                    Text("·")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.faint)
+                    Link("Create fine-grained token", destination: Self.newFineGrainedTokenURL)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.top, 2)
+
+                Text("Gitbar only sees what this token can access. Classic tokens need the `repo` scope; fine-grained tokens need pull-request / issues / metadata read access.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.meta)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section("Notifications") {
-                Toggle(isOn: $notifyReviews) {
+                HStack(spacing: 8) {
+                    Image(systemName: "bell.badge")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Theme.blue)
                     VStack(alignment: .leading, spacing: 1) {
-                        Text("Review requests")
-                        Text("Badge the menu bar icon when someone requests your review")
+                        Text("Coming soon — working on it :D")
+                            .font(.system(size: 12, weight: .medium))
+                        Text("Native macOS notifications for review requests, CI failures, and change requests.")
                             .font(.system(size: 11.5))
                             .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
+                    Spacer()
                 }
-                Toggle(isOn: $notifyCI) {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("CI failures")
-                        Text("Notify when CI fails on your PRs")
-                            .font(.system(size: 11.5))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Toggle(isOn: $notifyChangesRequested) {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text("PR needs changes")
-                        Text("Badge the menu bar icon when a reviewer requests changes on your PR")
-                            .font(.system(size: 11.5))
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                .padding(.vertical, 2)
             }
 
             Section("Behavior") {
@@ -168,6 +172,16 @@ struct SettingsView: View {
                     NSApplication.shared.terminate(nil)
                 }
                 .keyboardShortcut("q", modifiers: [.command])
+
+                Link(destination: URL(string: "https://github.com/brunokiafuka/gitbar/issues/new")!) {
+                    HStack(spacing: 6) {
+                        Text("🐛")
+                            .font(.system(size: 12))
+                        Text("Is it buggy? 😖 Open an issue here")
+                            .font(.system(size: 12))
+                    }
+                }
+                .buttonStyle(.link)
             }
 
             Section {
@@ -227,42 +241,6 @@ struct SettingsView: View {
             )
     }
 
-    private var tokenNotice: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 12))
-                .foregroundStyle(Theme.amber)
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Everything Gitbar sees is scoped to this token. Create, view, or rotate tokens on GitHub.")
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(.primary.opacity(0.92))
-                    .fixedSize(horizontal: false, vertical: true)
-                Link(destination: Self.newClassicTokenURL) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "link.circle.fill")
-                            .font(.system(size: 11))
-                        Text("Create classic token (repo scope)")
-                            .font(.system(size: 11.5, weight: .semibold))
-                    }
-                }
-                .buttonStyle(.link)
-                .tint(Theme.blue)
-                Link(destination: Self.newFineGrainedTokenURL) {
-                    Text("Create fine-grained token")
-                        .font(.system(size: 11))
-                }
-                .buttonStyle(.link)
-                .foregroundStyle(.secondary)
-            }
-        }
-        .padding(10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Theme.amber.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Theme.amber.opacity(0.22), lineWidth: 0.5)
-        )
-    }
 
     private func scopeRow(_ name: String, desc: String) -> some View {
         HStack(spacing: 10) {


### PR DESCRIPTION
## Summary
- Menu bar badge always sums PRs + review requests + assigned issues (issues were previously ignored in the default config).
- `contributesToBadge` on a section now only controls whether that section's header shows a count pill. New sections default pill-on.
- Includes prior UI polish commit (App/PanelView/Rows/SectionEditor/SettingsView).

## Test plan
- [ ] Launch app, verify menu bar number equals `myPRs + reviewRequests + issues`.
- [ ] In Manage Sections, toggle a section's pill off — header count pill disappears, menu bar number unchanged.
- [ ] Create a new section — "Show a count pill on this section's header" is checked by default.
- [ ] Assigned open issues now contribute to the menu bar number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)