### PR TITLE
feat: add "Waiting on author" review filter

### DIFF
--- a/Sources/Gitbar/Config.swift
+++ b/Sources/Gitbar/Config.swift
@@ -24,11 +24,50 @@ enum Config {
 
     static func readSectionsWithMigration() -> [PanelTab: [GitbarSection]] {
         var root = readRoot()
+        var dirty = false
         if root.sections == nil && root.sectionsSeeded != true {
             root.sections = GitbarSection.seededDefaults()
             root.sectionsSeeded = true
-            try? writeRoot(root)
+            dirty = true
         }
+        if var sections = root.sections {
+            var review = sections[.review] ?? []
+            var changed = false
+            // Drop the previously-seeded "Approved" section now that Waiting on author covers approved reviews.
+            let approvedLegacyID = UUID(uuidString: "D1D49A31-7B2E-4A07-8F2C-7E2A5E6E6E02")!
+            if let idx = review.firstIndex(where: { $0.id == approvedLegacyID }) {
+                review.remove(at: idx)
+                changed = true
+            }
+            let seeded = GitbarSection.seededReview()
+            if !review.contains(where: { $0.id == GitbarSection.waitingOnAuthorDefaultID }) {
+                if let template = seeded.first(where: { $0.id == GitbarSection.waitingOnAuthorDefaultID }) {
+                    var toAdd = template
+                    toAdd.order = (review.map(\.order).max() ?? -1) + 1
+                    review.append(toAdd)
+                    changed = true
+                }
+            } else if let idx = review.firstIndex(where: { $0.id == GitbarSection.waitingOnAuthorDefaultID }) {
+                // Upgrade existing default section to include `.approved` if it still carries the prior default set.
+                let legacyDefault = Set<ReviewedByMeStateValue>([.changesRequested, .commented])
+                let conditions = review[idx].filters.flatMap(\.conditions)
+                for cond in conditions {
+                    if case let .reviewedByMeState(op, values) = cond, Set(values) == legacyDefault {
+                        review[idx].filters = [SectionFilter(conditions: [
+                            .reviewedByMeState(op: op, values: ReviewedByMeStateValue.allCases)
+                        ])]
+                        changed = true
+                        break
+                    }
+                }
+            }
+            if changed {
+                sections[.review] = review
+                root.sections = sections
+                dirty = true
+            }
+        }
+        if dirty { try? writeRoot(root) }
         return root.sections ?? [:]
     }
 

--- a/Sources/Gitbar/GitHub.swift
+++ b/Sources/Gitbar/GitHub.swift
@@ -117,10 +117,12 @@ struct GHUserEvent: Decodable {
 struct GHReview: Decodable {
     let state: String // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING
     let submittedAt: String?
+    let user: GHUser?
 
     enum CodingKeys: String, CodingKey {
         case state
         case submittedAt = "submitted_at"
+        case user
     }
 }
 
@@ -212,6 +214,10 @@ actor GitHubClient {
         try await search(q: "type:pr state:open review-requested:@me sort:updated-desc")
     }
 
+    func reviewedByMe() async throws -> [GHIssue] {
+        try await search(q: "type:pr state:open reviewed-by:@me -author:@me sort:updated-desc")
+    }
+
     func assignedIssues() async throws -> [GHIssue] {
         try await search(q: "type:issue state:open assignee:@me sort:updated-desc")
     }
@@ -225,6 +231,18 @@ actor GitHubClient {
         ]
         return reviews
             .max(by: { (rank[$0.state] ?? 0) < (rank[$1.state] ?? 0) })?
+            .state
+    }
+
+    /// Most recent review submitted by `viewer` on this PR (APPROVED / CHANGES_REQUESTED / COMMENTED).
+    func viewerLatestReviewState(repo: String, pr: Int, viewer: String) async throws -> String? {
+        let url = reposURL(repo: repo, path: ["pulls", "\(pr)", "reviews"])
+        let data = try await get(url: url)
+        let reviews = try JSONDecoder().decode([GHReview].self, from: data)
+        return reviews
+            .filter { $0.user?.login.caseInsensitiveCompare(viewer) == .orderedSame }
+            .filter { $0.state == "APPROVED" || $0.state == "CHANGES_REQUESTED" || $0.state == "COMMENTED" }
+            .max(by: { ($0.submittedAt ?? "") < ($1.submittedAt ?? "") })?
             .state
     }
 

--- a/Sources/Gitbar/Sections.swift
+++ b/Sources/Gitbar/Sections.swift
@@ -46,6 +46,20 @@ enum SectionPRStatusValue: String, Codable, CaseIterable, Equatable, Sendable {
     case merging = "Merging"
 }
 
+enum ReviewedByMeStateValue: String, Codable, CaseIterable, Equatable, Sendable {
+    case approved = "APPROVED"
+    case changesRequested = "CHANGES_REQUESTED"
+    case commented = "COMMENTED"
+
+    var label: String {
+        switch self {
+        case .approved: return "Approved"
+        case .changesRequested: return "Changes requested"
+        case .commented: return "Commented"
+        }
+    }
+}
+
 enum SectionCondition: Codable, Equatable, Sendable {
     case prStatus(op: SectionSetOp, values: [SectionPRStatusValue])
     case author(op: SectionEqOp, login: String)
@@ -56,6 +70,7 @@ enum SectionCondition: Codable, Equatable, Sendable {
     case label(op: SectionSetOp, name: String)
     case assignee(op: SectionSetOp, login: String)
     case hasMergeConflict(is: Bool)
+    case reviewedByMeState(op: SectionSetOp, values: [ReviewedByMeStateValue])
 
     private enum CodingKeys: String, CodingKey {
         case kind, op, values, login, repos, isDraft, name, isOn
@@ -63,7 +78,7 @@ enum SectionCondition: Codable, Equatable, Sendable {
 
     private enum Kind: String, Codable {
         case prStatus, author, reviewer, repository, ciStatus, draft
-        case label, assignee, hasMergeConflict
+        case label, assignee, hasMergeConflict, reviewedByMeState
     }
 
     init(from decoder: Decoder) throws {
@@ -109,6 +124,11 @@ enum SectionCondition: Codable, Equatable, Sendable {
             )
         case .hasMergeConflict:
             self = .hasMergeConflict(is: try c.decode(Bool.self, forKey: .isOn))
+        case .reviewedByMeState:
+            self = .reviewedByMeState(
+                op: try c.decode(SectionSetOp.self, forKey: .op),
+                values: try c.decode([ReviewedByMeStateValue].self, forKey: .values)
+            )
         }
     }
 
@@ -149,6 +169,10 @@ enum SectionCondition: Codable, Equatable, Sendable {
         case .hasMergeConflict(let isOn):
             try c.encode(Kind.hasMergeConflict, forKey: .kind)
             try c.encode(isOn, forKey: .isOn)
+        case .reviewedByMeState(let op, let values):
+            try c.encode(Kind.reviewedByMeState, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(values, forKey: .values)
         }
     }
 }
@@ -166,9 +190,23 @@ struct GitbarSection: Codable, Identifiable, Equatable, Sendable {
     var collapsed: Bool
     var order: Int
     var isDefault: Bool = false
+
+    /// True when any filter uses a `.reviewedByMeState` condition — such sections draw from
+    /// the "reviewed-by-me" source rather than the review-request queue.
+    var targetsReviewedByMe: Bool {
+        filters.contains { f in
+            f.conditions.contains { c in
+                if case .reviewedByMeState = c { return true }
+                return false
+            }
+        }
+    }
 }
 
 extension GitbarSection {
+    /// Stable id for the seeded "Waiting on author" section so settings can locate it after edits.
+    static let waitingOnAuthorDefaultID = UUID(uuidString: "D1D49A31-7B2E-4A07-8F2C-7E2A5E6E6E01")!
+
     static func seededDefaults() -> [PanelTab: [GitbarSection]] {
         [
             .mine: seededMine(),
@@ -262,6 +300,21 @@ extension GitbarSection {
                 order: 2,
                 isDefault: true
             ),
+            GitbarSection(
+                id: waitingOnAuthorDefaultID,
+                name: "Waiting on author",
+                tab: .review,
+                repos: .defaults,
+                filters: [SectionFilter(conditions: [
+                    .reviewedByMeState(op: .includes, values: ReviewedByMeStateValue.allCases)
+                ])],
+                visibility: .visible,
+                contributesToBadge: false,
+                sort: .updatedDesc,
+                collapsed: false,
+                order: 3,
+                isDefault: true
+            ),
         ]
     }
 
@@ -344,6 +397,13 @@ struct SectionMatcher {
             case .hasMergeConflict(let expected):
                 let actual = metadata?.hasMergeConflict ?? false
                 return actual == expected
+            case .reviewedByMeState(let op, let values):
+                guard let raw = reviewState,
+                      let state = ReviewedByMeStateValue(rawValue: raw) else {
+                    return op == .excludes
+                }
+                let has = values.contains(state)
+                return includesEval(op: op, inSet: has)
             }
         }
     }
@@ -429,7 +489,7 @@ extension GitbarSection {
                     let qualifier = trimmed.contains(" ") ? "\"\(trimmed)\"" : trimmed
                     parts.append(op == .includes ? "label:\(qualifier)" : "-label:\(qualifier)")
                     hasScoping = true
-                case .reviewer, .ciStatus, .draft, .hasMergeConflict:
+                case .reviewer, .ciStatus, .draft, .hasMergeConflict, .reviewedByMeState:
                     // Not expressible in the issue search API; local matcher will evaluate if applicable.
                     break
                 }

--- a/Sources/Gitbar/Store.swift
+++ b/Sources/Gitbar/Store.swift
@@ -9,6 +9,7 @@ extension Notification.Name {
 final class Store: ObservableObject {
     @Published var myPRs: [GHIssue] = []
     @Published var reviewRequests: [GHIssue] = []
+    @Published var reviewedByMePRs: [GHIssue] = []
     @Published var issues: [GHIssue] = []
     /// Issues fetched per custom section in the Issues tab (keyed by section id).
     /// Populated when a user-created section's filters translate to a GitHub search.
@@ -18,6 +19,8 @@ final class Store: ObservableObject {
     @Published private(set) var viewer: GHViewer?
     /// Latest aggregated review state per PR (`GHIssue.id`) for the user's own PRs, e.g. `CHANGES_REQUESTED`.
     @Published var myPRReviewState: [Int: String] = [:]
+    /// Viewer's own most-recent review state per PR id for PRs the viewer has reviewed (others' PRs).
+    @Published var viewerReviewState: [Int: String] = [:]
     /// CI status, diff stats, merge conflict — from `GET /repos/.../pulls/{n}` + check-runs.
     @Published var prRowMetadata: [Int: PRRowMetadata] = [:]
     @Published var isLoading = false
@@ -67,6 +70,15 @@ final class Store: ObservableObject {
         myPRs.count + reviewRequests.count + issues.count
     }
 
+    /// Union of review-requested and reviewed-by-me PRs (deduped by id, request wins).
+    var reviewTabSourceRows: [GHIssue] {
+        var seen = Set<Int>()
+        var out: [GHIssue] = []
+        for pr in reviewRequests where seen.insert(pr.id).inserted { out.append(pr) }
+        for pr in reviewedByMePRs where seen.insert(pr.id).inserted { out.append(pr) }
+        return out
+    }
+
     func refresh() {
         refreshTask?.cancel()
         refreshTask = Task { await self.runRefresh() }
@@ -108,18 +120,29 @@ final class Store: ObservableObject {
             async let a = client.myPRs()
             async let b = client.reviewRequests()
             async let c = client.assignedIssues()
+            async let d = client.reviewedByMe()
             async let v = client.viewer()
-            let (prs, reviews, iss) = try await (a, b, c)
+            let (prs, reviews, iss, reviewedMe) = try await (a, b, c, d)
+            let viewerResult = try? await v
+            if let viewerResult {
+                self.viewer = viewerResult
+            }
             self.myPRs = prs
             self.reviewRequests = reviews
             self.issues = iss
+            // Exclude PRs still in the review-request queue; those are "needs your review", not "waiting on author".
+            let pendingIDs = Set(reviews.map(\.id))
+            let reviewedOnly = reviewedMe.filter { !pendingIDs.contains($0.id) }
+            self.reviewedByMePRs = reviewedOnly
             self.myPRReviewState = await Self.fetchMyPRReviewStates(client: client, prs: prs)
-            self.prRowMetadata = await Self.fetchPRRowMetadata(client: client, mine: prs, reviewQueue: reviews)
-            if let viewer = try? await v {
-                self.viewer = viewer
+            if let viewerLogin = viewerResult?.login ?? self.viewer?.login {
+                self.viewerReviewState = await Self.fetchViewerReviewStates(client: client, prs: reviewedOnly, viewer: viewerLogin)
+            } else {
+                self.viewerReviewState = [:]
             }
             let issueSections = self.sectionsByTab[.issues] ?? []
             self.issuesBySectionId = await Self.fetchIssueSections(client: client, sections: issueSections)
+            self.prRowMetadata = await Self.fetchPRRowMetadata(client: client, mine: prs, reviewQueue: reviews + reviewedOnly)
             self.errorMessage = nil
             self.lastRefreshed = Date()
             NotificationCenter.default.post(name: .gitbarStoreDidUpdate, object: self)
@@ -139,9 +162,11 @@ final class Store: ObservableObject {
             viewer = nil
             myPRs = []
             reviewRequests = []
+            reviewedByMePRs = []
             issues = []
             issuesBySectionId = [:]
             myPRReviewState = [:]
+            viewerReviewState = [:]
             prRowMetadata = [:]
             statsSnapshot = nil
             statsError = nil
@@ -289,6 +314,29 @@ final class Store: ObservableObject {
             var out: [UUID: [GHIssue]] = [:]
             for await (id, rows) in group {
                 out[id] = rows
+            }
+            return out
+        }
+    }
+
+    private static func fetchViewerReviewStates(client: GitHubClient, prs: [GHIssue], viewer: String) async -> [Int: String] {
+        guard !prs.isEmpty else { return [:] }
+        return await withTaskGroup(of: (Int, String?).self) { group in
+            for pr in prs {
+                group.addTask {
+                    let repo = pr.repoFull
+                    guard !repo.isEmpty else { return (pr.id, nil) }
+                    do {
+                        let state = try await client.viewerLatestReviewState(repo: repo, pr: pr.number, viewer: viewer)
+                        return (pr.id, state)
+                    } catch {
+                        return (pr.id, nil)
+                    }
+                }
+            }
+            var out: [Int: String] = [:]
+            for await (id, state) in group {
+                if let state { out[id] = state }
             }
             return out
         }

--- a/Sources/Gitbar/Views/Chips.swift
+++ b/Sources/Gitbar/Views/Chips.swift
@@ -38,10 +38,18 @@ struct PRStatusChip: View {
 
 struct AssigneeChip: View {
     @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject private var store: Store
     let login: String
 
+    private var displayText: String {
+        if let me = store.myLogin, login.caseInsensitiveCompare(me) == .orderedSame {
+            return "@me"
+        }
+        return "@\(login)"
+    }
+
     var body: some View {
-        Text("@\(login)")
+        Text(displayText)
             .font(.system(size: 10, weight: .medium))
             .foregroundStyle(.secondary)
             .padding(.horizontal, 6)

--- a/Sources/Gitbar/Views/LucideGithubIcons.swift
+++ b/Sources/Gitbar/Views/LucideGithubIcons.swift
@@ -17,6 +17,8 @@ enum LucideRepoIcon: Hashable, Sendable {
     case gitCommitHorizontal
     case timer
     case flame
+    case alertOctagon
+    case messageSquare
 }
 
 struct LucideRepoIconView: View {
@@ -67,6 +69,10 @@ struct LucideRepoIconView: View {
                 LucideTimerShape().stroke(style: strokeStyle).foregroundStyle(color)
             case .flame:
                 LucideFlameShape().stroke(style: strokeStyle).foregroundStyle(color)
+            case .alertOctagon:
+                LucideAlertOctagonShape().stroke(style: strokeStyle).foregroundStyle(color)
+            case .messageSquare:
+                LucideMessageSquareShape().stroke(style: strokeStyle).foregroundStyle(color)
             }
         }
         .frame(width: size, height: size)
@@ -250,5 +256,47 @@ private enum LucideGithubPath {
         let ox = rect.midX - 12 * sc
         let oy = rect.midY - 12 * sc
         return CGRect(x: ox + (cx - r) * sc, y: oy + (cy - r) * sc, width: 2 * r * sc, height: 2 * r * sc)
+    }
+}
+
+private struct LucideAlertOctagonShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let P = { LucideGithubPath.P($0, $1, rect) }
+        var p = Path()
+        // Octagon outline
+        p.move(to: P(7.86, 2))
+        p.addLine(to: P(16.14, 2))
+        p.addLine(to: P(22, 7.86))
+        p.addLine(to: P(22, 16.14))
+        p.addLine(to: P(16.14, 22))
+        p.addLine(to: P(7.86, 22))
+        p.addLine(to: P(2, 16.14))
+        p.addLine(to: P(2, 7.86))
+        p.closeSubpath()
+        // Exclamation stem
+        p.move(to: P(12, 8))
+        p.addLine(to: P(12, 12))
+        // Exclamation dot (small line segment so stroke renders)
+        p.move(to: P(12, 16))
+        p.addLine(to: P(12.01, 16))
+        return p
+    }
+}
+
+private struct LucideMessageSquareShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let P = { LucideGithubPath.P($0, $1, rect) }
+        var p = Path()
+        // Rounded-corner speech bubble: M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z
+        p.move(to: P(21, 15))
+        p.addQuadCurve(to: P(19, 17), control: P(21, 17))
+        p.addLine(to: P(7, 17))
+        p.addLine(to: P(3, 21))
+        p.addLine(to: P(3, 5))
+        p.addQuadCurve(to: P(5, 3), control: P(3, 3))
+        p.addLine(to: P(19, 3))
+        p.addQuadCurve(to: P(21, 5), control: P(21, 3))
+        p.closeSubpath()
+        return p
     }
 }

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -138,7 +138,7 @@ struct PanelView: View {
             .sorted { $0.key.uuidString < $1.key.uuidString }
             .map { "\($0.key.uuidString):\($0.value.map(\.id))" }
             .joined(separator: ",")
-        return "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))|\(customIssueIds)"
+        return "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.reviewedByMePRs.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))|\(customIssueIds)"
     }
 
     private let allTabPreviewLimit = 5
@@ -156,7 +156,7 @@ struct PanelView: View {
         case .mine:
             return sectionEntries(for: .mine, sourceRows: store.myPRs)
         case .review:
-            return sectionEntries(for: .review, sourceRows: store.reviewRequests)
+            return sectionEntries(for: .review, sourceRows: store.reviewTabSourceRows)
         case .issues:
             return sectionEntries(for: .issues, sourceRows: store.issues)
         }
@@ -188,20 +188,33 @@ struct PanelView: View {
 
     /// Rows for a single section. Issues-tab sections read remotely-fetched rows from the store
     /// (each section runs its filters as a GitHub search). PR-tab sections filter `sourceRows`
-    /// locally via the matcher.
+    /// locally via the matcher, with the Review tab splitting between the review-request queue
+    /// and reviewed-by-me PRs depending on the section's conditions.
     private func rowsForSection(_ section: GitbarSection, sourceRows: [GHIssue]) -> [GHIssue] {
         if section.tab == .issues {
             return store.issuesBySectionId[section.id] ?? []
         }
-        return sourceRows.filter {
+        let effectiveSource = sectionSource(for: section, tabSource: sourceRows)
+        return effectiveSource.filter {
             SectionMatcher.matches(
                 section: section,
                 row: $0,
                 viewerLogin: store.myLogin,
                 metadata: store.prRowMetadata[$0.id],
-                reviewState: store.myPRReviewState[$0.id]
+                reviewState: reviewState(for: $0, section: section)
             )
         }
+    }
+
+    private func sectionSource(for section: GitbarSection, tabSource: [GHIssue]) -> [GHIssue] {
+        guard section.tab == .review else { return tabSource }
+        return section.targetsReviewedByMe ? store.reviewedByMePRs : store.reviewRequests
+    }
+
+    private func reviewState(for row: GHIssue, section: GitbarSection) -> String? {
+        section.targetsReviewedByMe
+            ? store.viewerReviewState[row.id]
+            : store.myPRReviewState[row.id]
     }
 
     private func unmatchedRows(for tab: PanelTab, sourceRows: [GHIssue]) -> [GHIssue] {
@@ -210,7 +223,10 @@ struct PanelView: View {
                 .flatMap(\.rows)
                 .map(\.id)
         )
-        return sourceRows.filter { !matchedIDs.contains($0.id) }
+        // On the Review tab, the catch-all only surfaces PRs awaiting your review.
+        // Reviewed-by-me PRs only belong in their dedicated sections (e.g. Waiting on author).
+        let eligible: [GHIssue] = tab == .review ? store.reviewRequests : sourceRows
+        return eligible.filter { !matchedIDs.contains($0.id) }
     }
 
     private func sort(_ rows: [GHIssue], by choice: SortChoice) -> [GHIssue] {
@@ -448,7 +464,7 @@ struct PanelView: View {
                             ForEach(Array(store.myPRs.prefix(allTabPreviewLimit))) { pr in
                                 PRRow(
                                     pr: pr,
-                                    showAuthor: false,
+                                    showAuthor: true,
                                     reviewState: store.myPRReviewState[pr.id],
                                     metadata: store.prRowMetadata[pr.id],
                                     isSelected: isEntrySelected("all-m-\(pr.id)")
@@ -495,10 +511,10 @@ struct PanelView: View {
                             }
                         }
                         if tab == .mine {
-                            sectionDrivenList(tab: .mine, sourceRows: store.myPRs, showAuthor: false)
+                            sectionDrivenList(tab: .mine, sourceRows: store.myPRs, showAuthor: true)
                         }
                         if tab == .review {
-                            sectionDrivenList(tab: .review, sourceRows: store.reviewRequests, showAuthor: true)
+                            sectionDrivenList(tab: .review, sourceRows: store.reviewTabSourceRows, showAuthor: true)
                         }
                         if tab == .issues {
                             sectionDrivenIssues(tab: .issues, sourceRows: store.issues)
@@ -536,7 +552,8 @@ struct PanelView: View {
                     PRRow(
                         pr: row,
                         showAuthor: showAuthor,
-                        reviewState: store.myPRReviewState[row.id],
+                        reviewState: reviewState(for: row, section: sectionRows.section),
+                        reviewIsViewer: sectionRows.section.targetsReviewedByMe,
                         metadata: store.prRowMetadata[row.id],
                         isSelected: isEntrySelected("sec-\(sectionRows.section.id.uuidString)-\(row.id)")
                     )

--- a/Sources/Gitbar/Views/Rows.swift
+++ b/Sources/Gitbar/Views/Rows.swift
@@ -55,6 +55,9 @@ struct PRRow: View {
     let showAuthor: Bool
     /// Latest review aggregate for your own PRs (`CHANGES_REQUESTED`, `APPROVED`, …).
     var reviewState: String? = nil
+    /// When true, `reviewState` represents the viewer's own review (label as "you X").
+    /// When false, it's an aggregate of reviews left on the PR by others.
+    var reviewIsViewer: Bool = false
     /// CI, diff, merge conflict from REST; nil if still loading or request failed.
     var metadata: PRRowMetadata? = nil
     var isSelected: Bool = false
@@ -87,14 +90,7 @@ struct PRRow: View {
 
                     if showAuthor {
                         Text("·").foregroundStyle(Theme.faint.opacity(0.9))
-                        Text("@\(pr.user.login)")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
-                    }
-
-                    if !showAuthor {
-                        Text("·").foregroundStyle(Theme.faint.opacity(0.9))
-                        reviewStatusView
+                        AssigneeChip(login: pr.user.login)
                     }
 
                     if metadata?.hasMergeConflict == true {
@@ -134,6 +130,9 @@ struct PRRow: View {
                         .font(.system(size: 9.5))
                         .foregroundStyle(Theme.meta)
                 }
+                if let pill = reviewPillConfig {
+                    reviewPill(pill)
+                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
@@ -161,40 +160,46 @@ struct PRRow: View {
         .background(Theme.slate.opacity(0.14), in: RoundedRectangle(cornerRadius: 4))
     }
 
-    @ViewBuilder
-    private var reviewStatusView: some View {
-        HStack(spacing: 4) {
-            if reviewState == "APPROVED" || reviewState == "CHANGES_REQUESTED" {
-                Circle()
-                    .fill(reviewDotColor)
-                    .frame(width: 6, height: 6)
-            } else {
-                LucideRepoIconView(icon: .circleDotDashed, size: 11, color: reviewLineColor)
+    /// Shared per-state style for the review pill rendered on the third row.
+    private struct ReviewPillConfig {
+        let label: String
+        let color: Color
+        let icon: LucideRepoIcon
+    }
+
+    /// Pill config for the current review state. On viewer-review rows (Review tab)
+    /// we label what the viewer left, or render nothing if they haven't reviewed.
+    /// On aggregate rows (Mine tab) we render the PR's latest review outcome, including
+    /// a "pending" fallback when no review has been submitted yet.
+    private var reviewPillConfig: ReviewPillConfig? {
+        if reviewIsViewer {
+            switch reviewState {
+            case "APPROVED": return .init(label: "you approved", color: Theme.green, icon: .circleCheck)
+            case "CHANGES_REQUESTED": return .init(label: "you requested changes", color: Theme.red, icon: .alertOctagon)
+            case "COMMENTED": return .init(label: "you commented", color: Theme.amber, icon: .messageSquare)
+            default: return nil
             }
-            Text(reviewLineLabel)
-                .font(.system(size: 9.5, weight: .medium))
-                .foregroundStyle(reviewLineColor)
+        } else {
+            switch reviewState {
+            case "APPROVED": return .init(label: "approved", color: Theme.green, icon: .circleCheck)
+            case "CHANGES_REQUESTED": return .init(label: "changes requested", color: Theme.red, icon: .alertOctagon)
+            case "COMMENTED": return .init(label: "commented", color: Theme.amber, icon: .messageSquare)
+            default: return .init(label: "pending", color: Theme.slate, icon: .circleDotDashed)
+            }
         }
     }
 
-    private var reviewLineLabel: String {
-        switch reviewState {
-        case "APPROVED": return "approved"
-        case "CHANGES_REQUESTED": return "changes"
-        default: return "pending"
+    @ViewBuilder
+    private func reviewPill(_ config: ReviewPillConfig) -> some View {
+        HStack(spacing: 4) {
+            LucideRepoIconView(icon: config.icon, size: 10, color: config.color)
+            Text(config.label)
+                .font(.system(size: 9.5, weight: .semibold))
+                .foregroundStyle(config.color)
         }
-    }
-
-    private var reviewLineColor: Color {
-        switch reviewState {
-        case "APPROVED": return Theme.green
-        case "CHANGES_REQUESTED": return Theme.red
-        default: return Theme.slate
-        }
-    }
-
-    private var reviewDotColor: Color {
-        reviewLineColor
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(config.color.opacity(0.14), in: Capsule(style: .continuous))
     }
 
     private var rowBackground: Color {

--- a/Sources/Gitbar/Views/SectionEditorView.swift
+++ b/Sources/Gitbar/Views/SectionEditorView.swift
@@ -408,7 +408,7 @@ struct SectionEditorView: View {
     @ViewBuilder
     private func operatorPicker(for binding: Binding<ConditionDraft>) -> some View {
         switch binding.wrappedValue.field {
-        case .prStatus, .ciStatus, .reviewer, .assignee, .repository, .label:
+        case .prStatus, .ciStatus, .reviewer, .assignee, .repository, .label, .reviewedByMeState:
             Picker("", selection: binding.setOp) {
                 Text("is").tag(SectionSetOp.includes)
                 Text("is not").tag(SectionSetOp.excludes)
@@ -494,6 +494,15 @@ struct SectionEditorView: View {
             .labelsHidden()
             .controlSize(.small)
             .frame(width: 150)
+        case .reviewedByMeState:
+            multiSelectMenu(
+                title: summary(
+                    for: binding.wrappedValue.reviewedByMeStates.map(\.label),
+                    placeholder: "Select review"
+                ),
+                all: ReviewedByMeStateValue.allCases.map { ($0, $0.label) },
+                selection: binding.reviewedByMeStates
+            )
         }
     }
 
@@ -641,8 +650,10 @@ struct SectionEditorView: View {
         switch tab {
         case .issues:
             return [.prStatus, .author, .assignee, .repository, .label]
-        case .mine, .review:
+        case .mine:
             return [.prStatus, .author, .assignee, .repository, .label, .ciStatus, .draft]
+        case .review:
+            return [.prStatus, .author, .assignee, .repository, .label, .ciStatus, .draft, .reviewedByMeState]
         case .all, .stats:
             return [.prStatus, .author, .repository, .label]
         }
@@ -694,9 +705,10 @@ struct ConditionDraft: Identifiable, Equatable {
     var labelName: String = ""
     var isDraftValue: Bool = true
     var hasMergeConflictValue: Bool = true
+    var reviewedByMeStates: Set<ReviewedByMeStateValue> = [.changesRequested, .commented]
 
     enum Field: String, CaseIterable, Identifiable, Hashable {
-        case prStatus, author, reviewer, assignee, repository, label, ciStatus, draft, mergeConflict
+        case prStatus, author, reviewer, assignee, repository, label, ciStatus, draft, mergeConflict, reviewedByMeState
 
         var id: String { rawValue }
         func label(for tab: PanelTab) -> String {
@@ -710,6 +722,7 @@ struct ConditionDraft: Identifiable, Equatable {
             case .ciStatus: return "CI status"
             case .draft: return "Draft"
             case .mergeConflict: return "Merge conflict"
+            case .reviewedByMeState: return "Your review"
             }
         }
     }
@@ -751,6 +764,10 @@ struct ConditionDraft: Identifiable, Equatable {
         case .hasMergeConflict(let isOn):
             field = .mergeConflict
             hasMergeConflictValue = isOn
+        case .reviewedByMeState(let op, let values):
+            field = .reviewedByMeState
+            setOp = op
+            reviewedByMeStates = Set(values)
         }
     }
 
@@ -789,6 +806,9 @@ struct ConditionDraft: Identifiable, Equatable {
             return .repository(op: setOp, repos: repos)
         case .mergeConflict:
             return .hasMergeConflict(is: hasMergeConflictValue)
+        case .reviewedByMeState:
+            guard !reviewedByMeStates.isEmpty else { return nil }
+            return .reviewedByMeState(op: setOp, values: Array(reviewedByMeStates))
         }
     }
 }

--- a/Sources/Gitbar/Views/SettingsView.swift
+++ b/Sources/Gitbar/Views/SettingsView.swift
@@ -13,6 +13,9 @@ struct SettingsView: View {
     @AppStorage("gitbar.refreshInterval") private var refreshInterval = "60s"
     @State private var launchAtLogin = false
 
+    @State private var hideWaitingOnAuthor = false
+    @State private var waitingOnAuthorStates: Set<ReviewedByMeStateValue> = Set(ReviewedByMeStateValue.allCases)
+
     /// Classic PAT: pre-fills note + **repo** scope (pull requests, issues, metadata on repos you can access).
     private static let newClassicTokenURL: URL = {
         var c = URLComponents(string: "https://github.com/settings/tokens/new")!
@@ -132,6 +135,41 @@ struct SettingsView: View {
                 .padding(.vertical, 2)
             }
 
+            Section("Filters") {
+                Toggle(isOn: $hideWaitingOnAuthor) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Hide \u{201C}Waiting on author\u{201D}")
+                        Text("Removes the default section that surfaces PRs where you've requested changes or commented.")
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .onChange(of: hideWaitingOnAuthor) { _, new in
+                    setWaitingOnAuthorHidden(new)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Include reviews")
+                        Text("Which reviews of yours count as \u{201C}waiting on author\u{201D}.")
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(.secondary)
+                    }
+                    HStack(spacing: 16) {
+                        ForEach(ReviewedByMeStateValue.allCases, id: \.self) { state in
+                            Toggle(isOn: stateBinding(state)) {
+                                Text(state.label).font(.system(size: 12))
+                            }
+                            .toggleStyle(.checkbox)
+                            .disabled(hideWaitingOnAuthor)
+                        }
+                        Spacer()
+                    }
+                    .padding(.leading, 2)
+                }
+            }
+
             Section("Behavior") {
                 Toggle(isOn: $launchAtLogin) {
                     VStack(alignment: .leading, spacing: 1) {
@@ -196,7 +234,56 @@ struct SettingsView: View {
         .onAppear {
             tokenField = store.token ?? ""
             launchAtLogin = LaunchAtLogin.isEnabled
+            syncWaitingOnAuthorState()
         }
+    }
+
+    private func syncWaitingOnAuthorState() {
+        guard let section = waitingOnAuthorSection() else { return }
+        hideWaitingOnAuthor = section.visibility == .hidden
+        waitingOnAuthorStates = currentStates(in: section) ?? Set(ReviewedByMeStateValue.allCases)
+    }
+
+    private func waitingOnAuthorSection() -> GitbarSection? {
+        store.sections(for: .review).first { $0.id == GitbarSection.waitingOnAuthorDefaultID }
+    }
+
+    private func currentStates(in section: GitbarSection) -> Set<ReviewedByMeStateValue>? {
+        for cond in section.filters.flatMap(\.conditions) {
+            if case let .reviewedByMeState(_, values) = cond { return Set(values) }
+        }
+        return nil
+    }
+
+    private func setWaitingOnAuthorHidden(_ hidden: Bool) {
+        guard var section = waitingOnAuthorSection() else { return }
+        let newVisibility: SectionVisibility = hidden ? .hidden : .visible
+        guard section.visibility != newVisibility else { return }
+        section.visibility = newVisibility
+        store.updateSection(section)
+    }
+
+    private func stateBinding(_ state: ReviewedByMeStateValue) -> Binding<Bool> {
+        Binding(
+            get: { waitingOnAuthorStates.contains(state) },
+            set: { isOn in
+                var next = waitingOnAuthorStates
+                if isOn { next.insert(state) } else { next.remove(state) }
+                // At least one state must remain selected to keep the section meaningful.
+                guard !next.isEmpty else { return }
+                waitingOnAuthorStates = next
+                persistWaitingOnAuthorStates(next)
+            }
+        )
+    }
+
+    private func persistWaitingOnAuthorStates(_ states: Set<ReviewedByMeStateValue>) {
+        guard var section = waitingOnAuthorSection() else { return }
+        let ordered = ReviewedByMeStateValue.allCases.filter { states.contains($0) }
+        section.filters = [SectionFilter(conditions: [
+            .reviewedByMeState(op: .includes, values: ordered)
+        ])]
+        store.updateSection(section)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Closes #10.

Surfaces PRs you've reviewed where the ball is now in the author's court. Replaces the previously absent "reviewed" view with a default **Waiting on author** section on the Review tab.

<img width="566" height="666" alt="waiting-on-author" src="https://github.com/user-attachments/assets/5db73120-e9cc-44b7-bb1c-e316e2072406" />

## What's in

- New Review-tab section **Waiting on author**, backed by your latest review state on each PR (approved / commented / changes requested).
- New `reviewedByMeState` section condition so users can compose this into custom filters too.
- Per-row pill on the Review tab: green *you approved*, amber *you commented*, red *you requested changes* — each with its lucide icon.
- Settings → **Filters**: hide the section, or toggle which review states count (approved / changes requested / commented).
- Migration upgrades existing configs in place (seeds the new section, drops the short-lived Approved section, expands the filter to include approved).

## Test plan

- [ ] Fresh install: section appears under Review with the three state pills.
- [ ] Review a PR with changes / comment / approve → appears under Waiting on author on next refresh.
- [ ] Toggle a checkbox in Settings → Filters → the affected state stops showing up.
- [ ] Toggle "Hide Waiting on author" → section disappears; catch-all "All" stays limited to review-requested PRs.
- [ ] Existing configs on upgrade: the old Approved section is removed and the Waiting on author filter is widened to include approved reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)