### PR TITLE
feat: customizable issue filters

### DIFF
--- a/Sources/Gitbar/Sections.swift
+++ b/Sources/Gitbar/Sections.swift
@@ -312,7 +312,8 @@ struct SectionMatcher {
                 let normalizedValues = Set(values.map { $0 == .merging ? .merged : $0 })
                 return includesEval(op: op, inSet: normalizedValues.contains(status))
             case .author(let op, let login):
-                let equals = row.user.login.caseInsensitiveCompare(login) == .orderedSame
+                let resolved = resolveLogin(login, viewerLogin: viewerLogin)
+                let equals = row.user.login.caseInsensitiveCompare(resolved) == .orderedSame
                 return op == .is_ ? equals : !equals
             case .reviewer:
                 // Requested-reviewers aren't exposed by the search API; this filter
@@ -332,8 +333,13 @@ struct SectionMatcher {
                 let has = row.labels.contains { $0.name.lowercased() == needle }
                 return includesEval(op: op, inSet: has)
             case .assignee(let op, let login):
-                let needle = login.lowercased()
-                let has = (row.assignees ?? []).contains { $0.login.lowercased() == needle }
+                let has: Bool
+                if isUnassignedSentinel(login) {
+                    has = (row.assignees ?? []).isEmpty
+                } else {
+                    let needle = resolveLogin(login, viewerLogin: viewerLogin).lowercased()
+                    has = (row.assignees ?? []).contains { $0.login.lowercased() == needle }
+                }
                 return includesEval(op: op, inSet: has)
             case .hasMergeConflict(let expected):
                 let actual = metadata?.hasMergeConflict ?? false
@@ -349,5 +355,89 @@ struct SectionMatcher {
     private static func issueStatus(row: GHIssue) -> SectionPRStatusValue {
         if row.state.lowercased() == "open" { return .open }
         return row.pullRequest?.mergedAt != nil ? .merged : .closed
+    }
+
+    fileprivate static func resolveLogin(_ login: String, viewerLogin: String?) -> String {
+        let trimmed = login.trimmingCharacters(in: .whitespaces)
+        if trimmed.lowercased() == "@me", let me = viewerLogin { return me }
+        return trimmed
+    }
+
+    fileprivate static func isUnassignedSentinel(_ login: String) -> Bool {
+        let v = login.trimmingCharacters(in: .whitespaces).lowercased()
+        return v == "@none" || v == "unassigned"
+    }
+}
+
+// MARK: - Remote search translation (issues tab)
+
+extension GitbarSection {
+    /// Translates this section's filters into GitHub issue-search queries.
+    /// Each `SectionFilter` (OR'd at the section level) becomes one query whose
+    /// conditions (AND'd) are emitted as qualifiers. Sections without any
+    /// scoping condition (repo/label/author/assignee) implicitly scope to the
+    /// viewer (`assignee:@me`) so the remote result stays tractable.
+    func remoteIssueSearchQueries() -> [String] {
+        guard tab == .issues, !filters.isEmpty else { return [] }
+        return filters.map { filter in
+            var parts: [String] = ["type:issue"]
+            var hasScoping = false
+            var hasState = false
+            for cond in filter.conditions {
+                switch cond {
+                case .prStatus(let op, let values):
+                    // Issues only expose open/closed; legacy `.merging` + `.merged` collapse to `.closed`.
+                    let wanted: Set<SectionPRStatusValue> = Set(values.map { v -> SectionPRStatusValue in
+                        switch v {
+                        case .merging, .merged, .closed: return .closed
+                        case .open: return .open
+                        }
+                    })
+                    let target = op == .includes
+                        ? wanted
+                        : Set<SectionPRStatusValue>([.open, .closed]).subtracting(wanted)
+                    // Any state condition counts as a user-set state preference, even if
+                    // the target set is {open, closed} (== "any state", no qualifier needed).
+                    hasState = true
+                    if target == [.open] {
+                        parts.append("state:open")
+                    } else if target == [.closed] {
+                        parts.append("state:closed")
+                    }
+                case .author(let op, let login):
+                    let value = login.trimmingCharacters(in: .whitespaces)
+                    guard !value.isEmpty else { break }
+                    parts.append(op == .is_ ? "author:\(value)" : "-author:\(value)")
+                    hasScoping = true
+                case .assignee(let op, let login):
+                    if SectionMatcher.isUnassignedSentinel(login) {
+                        parts.append(op == .includes ? "no:assignee" : "assignee:*")
+                    } else {
+                        let value = login.trimmingCharacters(in: .whitespaces)
+                        guard !value.isEmpty else { break }
+                        parts.append(op == .includes ? "assignee:\(value)" : "-assignee:\(value)")
+                    }
+                    hasScoping = true
+                case .repository(let op, let repos):
+                    for repo in repos where !repo.trimmingCharacters(in: .whitespaces).isEmpty {
+                        parts.append(op == .includes ? "repo:\(repo)" : "-repo:\(repo)")
+                    }
+                    hasScoping = true
+                case .label(let op, let name):
+                    let trimmed = name.trimmingCharacters(in: .whitespaces)
+                    guard !trimmed.isEmpty else { break }
+                    let qualifier = trimmed.contains(" ") ? "\"\(trimmed)\"" : trimmed
+                    parts.append(op == .includes ? "label:\(qualifier)" : "-label:\(qualifier)")
+                    hasScoping = true
+                case .reviewer, .ciStatus, .draft, .hasMergeConflict:
+                    // Not expressible in the issue search API; local matcher will evaluate if applicable.
+                    break
+                }
+            }
+            if !hasScoping { parts.append("assignee:@me") }
+            if !hasState { parts.append("state:open") }
+            parts.append("sort:updated-desc")
+            return parts.joined(separator: " ")
+        }
     }
 }

--- a/Sources/Gitbar/Store.swift
+++ b/Sources/Gitbar/Store.swift
@@ -10,6 +10,10 @@ final class Store: ObservableObject {
     @Published var myPRs: [GHIssue] = []
     @Published var reviewRequests: [GHIssue] = []
     @Published var issues: [GHIssue] = []
+    /// Issues fetched per custom section in the Issues tab (keyed by section id).
+    /// Populated when a user-created section's filters translate to a GitHub search.
+    /// The default "Assigned issues" section is not in this map — it reads from `issues`.
+    @Published var issuesBySectionId: [UUID: [GHIssue]] = [:]
     /// From `GET /user` when the token is valid; cleared on sign-out.
     @Published private(set) var viewer: GHViewer?
     /// Latest aggregated review state per PR (`GHIssue.id`) for the user's own PRs, e.g. `CHANGES_REQUESTED`.
@@ -114,6 +118,8 @@ final class Store: ObservableObject {
             if let viewer = try? await v {
                 self.viewer = viewer
             }
+            let issueSections = self.sectionsByTab[.issues] ?? []
+            self.issuesBySectionId = await Self.fetchIssueSections(client: client, sections: issueSections)
             self.errorMessage = nil
             self.lastRefreshed = Date()
             NotificationCenter.default.post(name: .gitbarStoreDidUpdate, object: self)
@@ -134,6 +140,7 @@ final class Store: ObservableObject {
             myPRs = []
             reviewRequests = []
             issues = []
+            issuesBySectionId = [:]
             myPRReviewState = [:]
             prRowMetadata = [:]
             statsSnapshot = nil
@@ -159,6 +166,7 @@ final class Store: ObservableObject {
             next[section.tab] = list
             sectionsByTab = next
             try? Config.saveSections(next)
+            if section.tab == .issues { refresh() }
         }
     }
 
@@ -171,6 +179,7 @@ final class Store: ObservableObject {
         next[section.tab] = list
         sectionsByTab = next
         try? Config.saveSections(next)
+        if toInsert.tab == .issues { refresh() }
     }
 
     func deleteSection(id: UUID, tab: PanelTab) {
@@ -182,6 +191,7 @@ final class Store: ObservableObject {
         next[tab] = list
         sectionsByTab = next
         try? Config.saveSections(next)
+        if tab == .issues { issuesBySectionId.removeValue(forKey: id) }
     }
 
     /// Moves `id` within `tab`. When `targetID` is nil, appends to the end.
@@ -248,6 +258,40 @@ final class Store: ObservableObject {
     func stopPolling() {
         pollTimer?.invalidate()
         pollTimer = nil
+    }
+
+    private static func fetchIssueSections(
+        client: GitHubClient,
+        sections: [GitbarSection]
+    ) async -> [UUID: [GHIssue]] {
+        guard !sections.isEmpty else { return [:] }
+        return await withTaskGroup(of: (UUID, [GHIssue]).self) { group in
+            for section in sections {
+                let queries = section.remoteIssueSearchQueries()
+                guard !queries.isEmpty else { continue }
+                group.addTask {
+                    var seen = Set<Int>()
+                    var merged: [GHIssue] = []
+                    for q in queries {
+                        let rows: [GHIssue]
+                        do {
+                            rows = try await client.searchIssues(q: q, perPage: 50)
+                        } catch {
+                            rows = []
+                        }
+                        for row in rows where seen.insert(row.id).inserted {
+                            merged.append(row)
+                        }
+                    }
+                    return (section.id, merged)
+                }
+            }
+            var out: [UUID: [GHIssue]] = [:]
+            for await (id, rows) in group {
+                out[id] = rows
+            }
+            return out
+        }
     }
 
     private static func fetchMyPRReviewStates(client: GitHubClient, prs: [GHIssue]) async -> [Int: String] {

--- a/Sources/Gitbar/Views/Chips.swift
+++ b/Sources/Gitbar/Views/Chips.swift
@@ -36,6 +36,106 @@ struct PRStatusChip: View {
     }
 }
 
+struct AssigneeChip: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let login: String
+
+    var body: some View {
+        Text("@\(login)")
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background(Theme.surfaceHi(colorScheme), in: RoundedRectangle(cornerRadius: 4))
+    }
+}
+
+struct OverflowPill: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let count: Int
+
+    var body: some View {
+        Text("+\(count)")
+            .font(.system(size: 10, weight: .semibold).monospacedDigit())
+            .foregroundStyle(Theme.meta)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Theme.surfaceHi(colorScheme).opacity(0.7), in: RoundedRectangle(cornerRadius: 4))
+    }
+}
+
+struct UnassignedChip: View {
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "person.crop.circle.dashed")
+                .font(.system(size: 9, weight: .semibold))
+            Text("unassigned")
+                .font(.system(size: 10, weight: .medium))
+        }
+        .foregroundStyle(Theme.amber)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(Theme.amber.opacity(0.14), in: RoundedRectangle(cornerRadius: 4))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .strokeBorder(Theme.amber.opacity(0.35), style: StrokeStyle(lineWidth: 0.5, dash: [2, 2]))
+        )
+    }
+}
+
+/// Wraps children onto multiple lines when they don't fit in one row. macOS 13+.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+    var rowSpacing: CGFloat = 4
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = rows(maxWidth: maxWidth, subviews: subviews)
+        let totalHeight = rows.reduce(0) { $0 + $1.height } + max(0, CGFloat(rows.count - 1)) * rowSpacing
+        let usedWidth = rows.map(\.width).max() ?? 0
+        return CGSize(width: min(usedWidth, maxWidth.isFinite ? maxWidth : usedWidth), height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = rows(maxWidth: bounds.width, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for item in row.items {
+                subviews[item.index].place(
+                    at: CGPoint(x: x, y: y + (row.height - item.size.height) / 2),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(item.size)
+                )
+                x += item.size.width + spacing
+            }
+            y += row.height + rowSpacing
+        }
+    }
+
+    private struct RowItem { let index: Int; let size: CGSize }
+    private struct Row { var items: [RowItem]; var height: CGFloat; var width: CGFloat }
+
+    private func rows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var out: [Row] = []
+        var current = Row(items: [], height: 0, width: 0)
+        for (i, sub) in subviews.enumerated() {
+            let size = sub.sizeThatFits(.unspecified)
+            let projected = current.items.isEmpty ? size.width : current.width + spacing + size.width
+            if !current.items.isEmpty, projected > maxWidth {
+                out.append(current)
+                current = Row(items: [RowItem(index: i, size: size)], height: size.height, width: size.width)
+            } else {
+                current.items.append(RowItem(index: i, size: size))
+                current.height = max(current.height, size.height)
+                current.width = projected
+            }
+        }
+        if !current.items.isEmpty { out.append(current) }
+        return out
+    }
+}
+
 struct LabelPill: View {
     @Environment(\.colorScheme) private var colorScheme
     let label: GHLabel

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -134,7 +134,11 @@ struct PanelView: View {
     }
 
     private var listSignature: String {
-        "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))"
+        let customIssueIds = store.issuesBySectionId
+            .sorted { $0.key.uuidString < $1.key.uuidString }
+            .map { "\($0.key.uuidString):\($0.value.map(\.id))" }
+            .joined(separator: ",")
+        return "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))|\(customIssueIds)"
     }
 
     private let allTabPreviewLimit = 5
@@ -176,18 +180,28 @@ struct PanelView: View {
         store.sections(for: tab)
             .filter { $0.visibility != .hidden }
             .map { section in
-                let rows = sourceRows.filter {
-                    SectionMatcher.matches(
-                        section: section,
-                        row: $0,
-                        viewerLogin: store.myLogin,
-                        metadata: store.prRowMetadata[$0.id],
-                        reviewState: store.myPRReviewState[$0.id]
-                    )
-                }
+                let rows = rowsForSection(section, sourceRows: sourceRows)
                 return TabSectionRows(section: section, rows: sort(rows, by: section.sort))
             }
             .filter { !$0.rows.isEmpty }
+    }
+
+    /// Rows for a single section. Issues-tab sections read remotely-fetched rows from the store
+    /// (each section runs its filters as a GitHub search). PR-tab sections filter `sourceRows`
+    /// locally via the matcher.
+    private func rowsForSection(_ section: GitbarSection, sourceRows: [GHIssue]) -> [GHIssue] {
+        if section.tab == .issues {
+            return store.issuesBySectionId[section.id] ?? []
+        }
+        return sourceRows.filter {
+            SectionMatcher.matches(
+                section: section,
+                row: $0,
+                viewerLogin: store.myLogin,
+                metadata: store.prRowMetadata[$0.id],
+                reviewState: store.myPRReviewState[$0.id]
+            )
+        }
     }
 
     private func unmatchedRows(for tab: PanelTab, sourceRows: [GHIssue]) -> [GHIssue] {
@@ -791,10 +805,12 @@ struct PanelView: View {
     private var showIssues: Bool { tab == .all || tab == .issues }
 
     private var isEmpty: Bool {
-        (tab == .all    && store.myPRs.isEmpty && store.reviewRequests.isEmpty && store.issues.isEmpty) ||
-        (tab == .mine   && store.myPRs.isEmpty) ||
-        (tab == .review && store.reviewRequests.isEmpty) ||
-        (tab == .issues && store.issues.isEmpty)
+        let customIssueRowCount = store.issuesBySectionId.values.reduce(0) { $0 + $1.count }
+        return
+            (tab == .all    && store.myPRs.isEmpty && store.reviewRequests.isEmpty && store.issues.isEmpty) ||
+            (tab == .mine   && store.myPRs.isEmpty) ||
+            (tab == .review && store.reviewRequests.isEmpty) ||
+            (tab == .issues && store.issues.isEmpty && customIssueRowCount == 0)
     }
 
     private var emptyState: some View {

--- a/Sources/Gitbar/Views/Rows.swift
+++ b/Sources/Gitbar/Views/Rows.swift
@@ -228,22 +228,42 @@ struct IssueRow: View {
                         .font(Theme.monoTiny)
                         .foregroundStyle(Theme.meta)
                 }
-                HStack(spacing: 6) {
+                FlowLayout(spacing: 6, rowSpacing: 4) {
                     Text(issue.repoShort)
                         .font(Theme.monoTiny)
                         .foregroundStyle(.secondary)
-                    Text("·").foregroundStyle(Theme.faint.opacity(0.9))
-                    ForEach(issue.labels.prefix(3)) { label in
-                        LabelPill(label: label)
+
+                    let assignees = issue.assignees ?? []
+                    dotSeparator
+                    if let first = assignees.first {
+                        AssigneeChip(login: first.login)
+                        if assignees.count > 1 {
+                            OverflowPill(count: assignees.count - 1)
+                        }
+                    } else {
+                        UnassignedChip()
                     }
-                    Spacer()
+
+                    if !issue.labels.isEmpty {
+                        dotSeparator
+                        ForEach(issue.labels.prefix(2)) { label in
+                            LabelPill(label: label)
+                        }
+                        if issue.labels.count > 2 {
+                            OverflowPill(count: issue.labels.count - 2)
+                        }
+                    }
+
                     if issue.comments > 0 {
+                        dotSeparator
                         HStack(spacing: 3) {
                             LucideRepoIconView(icon: .messageSquareDiff, size: 11, color: .secondary)
                             Text("\(issue.comments)").font(.system(size: 9.5))
                         }
                         .foregroundStyle(.secondary)
                     }
+
+                    dotSeparator
                     Text(RelativeTime.short(issue.updated))
                         .font(.system(size: 9.5))
                         .foregroundStyle(Theme.meta)
@@ -264,6 +284,10 @@ struct IssueRow: View {
 
     private var rowBackground: Color {
         (hovered || isSelected) ? Theme.surfaceHi(colorScheme) : .clear
+    }
+
+    private var dotSeparator: some View {
+        Text("·").foregroundStyle(Theme.faint.opacity(0.9))
     }
 
     private func openInBrowser() {

--- a/Sources/Gitbar/Views/SectionEditorView.swift
+++ b/Sources/Gitbar/Views/SectionEditorView.swift
@@ -74,6 +74,9 @@ struct SectionEditorView: View {
             Divider().overlay(Theme.hairline(colorScheme))
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
+                    if showsDefaultIssuesNotice {
+                        defaultIssuesNotice
+                    }
                     nameSection
                     repositoriesSection
                     filtersSection
@@ -119,6 +122,34 @@ struct SectionEditorView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
+    }
+
+    private var showsDefaultIssuesNotice: Bool {
+        mode.tab == .issues && (mode.section?.isDefault ?? false)
+    }
+
+    private var defaultIssuesNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.blue)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Built-in filter — scoped to issues assigned to you.")
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text("For custom scopes (a specific repo, label, or another user), create a new filter. You can hide this one under Visibility.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.meta)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Theme.blue.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8).stroke(Theme.blue.opacity(0.25), lineWidth: 0.5)
+        )
     }
 
     private var nameSection: some View {
@@ -198,6 +229,12 @@ struct SectionEditorView: View {
             Text("Rows inside a filter are ANDed; filters are ORed.")
                 .font(.system(size: 10.5))
                 .foregroundStyle(Theme.meta)
+            if mode.tab == .issues, !(mode.section?.isDefault ?? false) {
+                Text("Runs as a GitHub search. Scope with a repo, label, author, or assignee — otherwise defaults to issues assigned to you.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.meta)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
             VStack(spacing: 8) {
                 ForEach(Array(filters.enumerated()), id: \.element.id) { filterIndex, filter in
@@ -417,7 +454,7 @@ struct SectionEditorView: View {
                 selection: binding.ciStatuses
             )
         case .author:
-            TextField("GitHub username", text: binding.authorLogin)
+            TextField("login or @me", text: binding.authorLogin)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
@@ -427,7 +464,7 @@ struct SectionEditorView: View {
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
         case .assignee:
-            TextField("GitHub username", text: binding.assigneeLogin)
+            TextField("login, @me, or @none", text: binding.assigneeLogin)
                 .textFieldStyle(.roundedBorder)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
Closes #11.

Widens the Issues tab beyond the hardcoded `assignee:@me` scope. Each Issues-tab section now translates its filters into a GitHub issue search, so users can track issues in a specific repo, by label, assigned to a teammate, or unassigned triage queues — not only issues assigned to them.

<img width="566" height="666" alt="Screenshot 2026-04-24 at 22 05 28" src="https://github.com/user-attachments/assets/5eae3640-5db3-43d8-929e-62e74853b2d4" />


## What's in

- `GitbarSection.remoteIssueSearchQueries()` — translates section filters into GitHub search qualifiers (`repo:`, `label:`, `author:`, `assignee:`, `no:assignee`, `state:`), OR'd across `SectionFilter`s.
- `Store` fetches each Issues-tab section's remote query in parallel into a new `issuesBySectionId` map; section mutations on the Issues tab trigger a refresh and invalidate stale entries on delete / sign-out.
- Matcher resolves `@me` (against viewer login) and `@none` / `unassigned` (empty assignees) in `.assignee` conditions.
- PanelView renders Issues-tab section rows from `issuesBySectionId` (falling back to assigned-issues for unmatched rows), with `listSignature` and `isEmpty` widened to observe the new map.
- Editor polish: assignee/author placeholder mentions `@me` / `@none`; non-default Issues sections show a one-liner hint that filters run as a GitHub search; the default "Assigned issues" section shows a blue info banner explaining it's scoped to `@me` and pointing to create-new + hide for customization.
- Row polish: new `FlowLayout` wraps the metadata row; `AssigneeChip` / `OverflowPill` / `UnassignedChip` (amber dashed) surface first assignee + `+N`, first two labels + `+N`, or an explicit "unassigned" marker when nobody's on it.

## Test plan

- [ ] Create a new Issues filter scoped to `Repository = owner/repo` — rows from that repo appear (including unassigned and other users').
- [ ] Create one scoped to `Assignee = @none` — only unassigned issues show; each renders the amber `unassigned` chip.
- [ ] Create one scoped to `Assignee = some-teammate` — their issues show up.
- [ ] Set `Issue status` to both Open and Closed — both states appear (no silent fallback to open-only).
- [ ] Edit the default "Assigned issues" filter — blue info banner is visible at the top of the editor.
- [ ] Hide the default filter via Visibility → Hidden — only custom sections render on the Issues tab.
- [ ] Delete a custom section — its rows disappear immediately (map entry cleared), no stale badge count.
- [ ] Issue with 3+ labels shows first 2 + `+N`; issue with 2+ assignees shows `@first +N`; metadata row wraps to a second line on narrow content instead of clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)