### PR TITLE
Review-tab scoping filters widen sections

### DIFF
--- a/Sources/Gitbar/Sections.swift
+++ b/Sources/Gitbar/Sections.swift
@@ -71,6 +71,7 @@ enum SectionCondition: Codable, Equatable, Sendable {
     case assignee(op: SectionSetOp, login: String)
     case hasMergeConflict(is: Bool)
     case reviewedByMeState(op: SectionSetOp, values: [ReviewedByMeStateValue])
+    case reviewedBy(op: SectionEqOp, login: String)
 
     private enum CodingKeys: String, CodingKey {
         case kind, op, values, login, repos, isDraft, name, isOn
@@ -79,6 +80,7 @@ enum SectionCondition: Codable, Equatable, Sendable {
     private enum Kind: String, Codable {
         case prStatus, author, reviewer, repository, ciStatus, draft
         case label, assignee, hasMergeConflict, reviewedByMeState
+        case reviewedBy
     }
 
     init(from decoder: Decoder) throws {
@@ -129,6 +131,11 @@ enum SectionCondition: Codable, Equatable, Sendable {
                 op: try c.decode(SectionSetOp.self, forKey: .op),
                 values: try c.decode([ReviewedByMeStateValue].self, forKey: .values)
             )
+        case .reviewedBy:
+            self = .reviewedBy(
+                op: try c.decode(SectionEqOp.self, forKey: .op),
+                login: try c.decode(String.self, forKey: .login)
+            )
         }
     }
 
@@ -173,6 +180,10 @@ enum SectionCondition: Codable, Equatable, Sendable {
             try c.encode(Kind.reviewedByMeState, forKey: .kind)
             try c.encode(op, forKey: .op)
             try c.encode(values, forKey: .values)
+        case .reviewedBy(let op, let login):
+            try c.encode(Kind.reviewedBy, forKey: .kind)
+            try c.encode(op, forKey: .op)
+            try c.encode(login, forKey: .login)
         }
     }
 }
@@ -199,6 +210,49 @@ struct GitbarSection: Codable, Identifiable, Equatable, Sendable {
                 if case .reviewedByMeState = c { return true }
                 return false
             }
+        }
+    }
+
+    /// True when any filter has a scoping condition (repo / author / assignee / label / reviewer)
+    /// with a non-empty value. On the Review tab this widens the section to a per-section
+    /// GitHub search instead of filtering the local review queue.
+    var hasScopingCondition: Bool {
+        filters.contains { f in f.conditions.contains(where: { $0.isScoping }) }
+    }
+}
+
+extension SectionCondition {
+    /// Conditions that scope what GitHub returns (repo / author / assignee / label / reviewer
+    /// / reviewedBy). Their presence on a Review section flips it from queue-filtering to
+    /// widened search.
+    var isScoping: Bool {
+        switch self {
+        case .repository(_, let repos):
+            return repos.contains { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        case .author(_, let login):
+            return !login.trimmingCharacters(in: .whitespaces).isEmpty
+        case .assignee(_, let login):
+            return !login.trimmingCharacters(in: .whitespaces).isEmpty
+        case .label(_, let name):
+            return !name.trimmingCharacters(in: .whitespaces).isEmpty
+        case .reviewer(_, let login):
+            return !login.trimmingCharacters(in: .whitespaces).isEmpty
+        case .reviewedBy(_, let login):
+            return !login.trimmingCharacters(in: .whitespaces).isEmpty
+        case .prStatus, .ciStatus, .draft, .hasMergeConflict, .reviewedByMeState:
+            return false
+        }
+    }
+
+    /// Conditions whose evaluation requires per-PR metadata not fetched for outside-queue rows.
+    /// On widened Review sections these are display-only — the editor flags them with a warning
+    /// and the runtime ignores them (matcher isn't run on widened sections).
+    var requiresFetchedMetadata: Bool {
+        switch self {
+        case .ciStatus, .hasMergeConflict, .reviewedByMeState:
+            return true
+        case .prStatus, .author, .assignee, .repository, .label, .reviewer, .draft, .reviewedBy:
+            return false
         }
     }
 }
@@ -404,6 +458,18 @@ struct SectionMatcher {
                 }
                 let has = values.contains(state)
                 return includesEval(op: op, inSet: has)
+            case .reviewedBy(let op, let login):
+                // `reviewedBy` is a scoping condition — sections carrying it widen to a remote
+                // search and the matcher isn't run for them. For arbitrary logins we have no
+                // local signal; the only login we can answer for is the viewer (`@me`), via the
+                // existing `reviewState` lookup.
+                let resolved = resolveLogin(login, viewerLogin: viewerLogin)
+                guard let me = viewerLogin,
+                      resolved.caseInsensitiveCompare(me) == .orderedSame else {
+                    return false
+                }
+                let actuallyReviewed = reviewState != nil
+                return op == .is_ ? actuallyReviewed : !actuallyReviewed
             }
         }
     }
@@ -489,12 +555,98 @@ extension GitbarSection {
                     let qualifier = trimmed.contains(" ") ? "\"\(trimmed)\"" : trimmed
                     parts.append(op == .includes ? "label:\(qualifier)" : "-label:\(qualifier)")
                     hasScoping = true
-                case .reviewer, .ciStatus, .draft, .hasMergeConflict, .reviewedByMeState:
-                    // Not expressible in the issue search API; local matcher will evaluate if applicable.
+                case .reviewer, .ciStatus, .draft, .hasMergeConflict, .reviewedByMeState,
+                     .reviewedBy:
+                    // Either not expressible in the issue search API, or not exposed on the
+                    // Issues tab editor; local matcher will evaluate if applicable.
                     break
                 }
             }
             if !hasScoping { parts.append("assignee:@me") }
+            if !hasState { parts.append("state:open") }
+            parts.append("sort:updated-desc")
+            return parts.joined(separator: " ")
+        }
+    }
+}
+
+// MARK: - Remote search translation (review tab, widened)
+
+extension GitbarSection {
+    /// Translates a Review-tab section's filters into per-section PR-search queries.
+    /// Only emitted when the section has a scoping condition (`hasScopingCondition`); otherwise
+    /// the section continues to filter the local review queue. Filters within a widened section
+    /// that lack their own scoping qualifier fall back to `review-requested:@me` so the
+    /// non-scoped filter still represents the user's review queue. Defaults to `state:open`.
+    func remoteReviewSearchQueries() -> [String] {
+        guard tab == .review, hasScopingCondition else { return [] }
+        return filters.map { filter in
+            var parts: [String] = ["type:pr"]
+            var hasScoping = false
+            var hasState = false
+            for cond in filter.conditions {
+                switch cond {
+                case .prStatus(let op, let values):
+                    let wanted: Set<SectionPRStatusValue> = Set(values.map { v -> SectionPRStatusValue in
+                        switch v {
+                        case .merging, .merged, .closed: return .closed
+                        case .open: return .open
+                        }
+                    })
+                    let target = op == .includes
+                        ? wanted
+                        : Set<SectionPRStatusValue>([.open, .closed]).subtracting(wanted)
+                    hasState = true
+                    if target == [.open] {
+                        parts.append("state:open")
+                    } else if target == [.closed] {
+                        parts.append("state:closed")
+                    }
+                case .author(let op, let login):
+                    let value = login.trimmingCharacters(in: .whitespaces)
+                    guard !value.isEmpty else { break }
+                    parts.append(op == .is_ ? "author:\(value)" : "-author:\(value)")
+                    hasScoping = true
+                case .assignee(let op, let login):
+                    if SectionMatcher.isUnassignedSentinel(login) {
+                        parts.append(op == .includes ? "no:assignee" : "assignee:*")
+                        hasScoping = true
+                    } else {
+                        let value = login.trimmingCharacters(in: .whitespaces)
+                        guard !value.isEmpty else { break }
+                        parts.append(op == .includes ? "assignee:\(value)" : "-assignee:\(value)")
+                        hasScoping = true
+                    }
+                case .repository(let op, let repos):
+                    for repo in repos where !repo.trimmingCharacters(in: .whitespaces).isEmpty {
+                        parts.append(op == .includes ? "repo:\(repo)" : "-repo:\(repo)")
+                        hasScoping = true
+                    }
+                case .label(let op, let name):
+                    let trimmed = name.trimmingCharacters(in: .whitespaces)
+                    guard !trimmed.isEmpty else { break }
+                    let qualifier = trimmed.contains(" ") ? "\"\(trimmed)\"" : trimmed
+                    parts.append(op == .includes ? "label:\(qualifier)" : "-label:\(qualifier)")
+                    hasScoping = true
+                case .reviewer(let op, let login):
+                    let value = login.trimmingCharacters(in: .whitespaces)
+                    guard !value.isEmpty else { break }
+                    parts.append(op == .includes ? "review-requested:\(value)" : "-review-requested:\(value)")
+                    hasScoping = true
+                case .draft(let isDraft):
+                    parts.append(isDraft ? "draft:true" : "draft:false")
+                case .reviewedBy(let op, let login):
+                    let value = login.trimmingCharacters(in: .whitespaces)
+                    guard !value.isEmpty else { break }
+                    parts.append(op == .is_ ? "reviewed-by:\(value)" : "-reviewed-by:\(value)")
+                    hasScoping = true
+                case .ciStatus, .hasMergeConflict, .reviewedByMeState:
+                    // Not expressible in the issue-search API — runtime ignores these on widened
+                    // sections and the editor surfaces a warning row.
+                    break
+                }
+            }
+            if !hasScoping { parts.append("review-requested:@me") }
             if !hasState { parts.append("state:open") }
             parts.append("sort:updated-desc")
             return parts.joined(separator: " ")

--- a/Sources/Gitbar/Store.swift
+++ b/Sources/Gitbar/Store.swift
@@ -11,10 +11,12 @@ final class Store: ObservableObject {
     @Published var reviewRequests: [GHIssue] = []
     @Published var reviewedByMePRs: [GHIssue] = []
     @Published var issues: [GHIssue] = []
-    /// Issues fetched per custom section in the Issues tab (keyed by section id).
-    /// Populated when a user-created section's filters translate to a GitHub search.
-    /// The default "Assigned issues" section is not in this map — it reads from `issues`.
-    @Published var issuesBySectionId: [UUID: [GHIssue]] = [:]
+    /// Rows fetched per section that runs as a per-section GitHub search (keyed by section id).
+    /// Populated for: every Issues-tab section whose filters translate to a search query, and
+    /// every Review-tab section whose filters carry a scoping condition (`hasScopingCondition`).
+    /// Sections that filter the local queue (default "Assigned issues", default Review sections)
+    /// are not in this map.
+    @Published var customSectionRows: [UUID: [GHIssue]] = [:]
     /// From `GET /user` when the token is valid; cleared on sign-out.
     @Published private(set) var viewer: GHViewer?
     /// Latest aggregated review state per PR (`GHIssue.id`) for the user's own PRs, e.g. `CHANGES_REQUESTED`.
@@ -140,8 +142,9 @@ final class Store: ObservableObject {
             } else {
                 self.viewerReviewState = [:]
             }
-            let issueSections = self.sectionsByTab[.issues] ?? []
-            self.issuesBySectionId = await Self.fetchIssueSections(client: client, sections: issueSections)
+            let customRowSections = (self.sectionsByTab[.issues] ?? [])
+                + (self.sectionsByTab[.review] ?? []).filter { $0.hasScopingCondition }
+            self.customSectionRows = await Self.fetchCustomSectionRows(client: client, sections: customRowSections)
             self.prRowMetadata = await Self.fetchPRRowMetadata(client: client, mine: prs, reviewQueue: reviews + reviewedOnly)
             self.errorMessage = nil
             self.lastRefreshed = Date()
@@ -164,7 +167,7 @@ final class Store: ObservableObject {
             reviewRequests = []
             reviewedByMePRs = []
             issues = []
-            issuesBySectionId = [:]
+            customSectionRows = [:]
             myPRReviewState = [:]
             viewerReviewState = [:]
             prRowMetadata = [:]
@@ -191,7 +194,7 @@ final class Store: ObservableObject {
             next[section.tab] = list
             sectionsByTab = next
             try? Config.saveSections(next)
-            if section.tab == .issues { refresh() }
+            if section.tab == .issues || section.tab == .review { refresh() }
         }
     }
 
@@ -204,7 +207,7 @@ final class Store: ObservableObject {
         next[section.tab] = list
         sectionsByTab = next
         try? Config.saveSections(next)
-        if toInsert.tab == .issues { refresh() }
+        if toInsert.tab == .issues || toInsert.tab == .review { refresh() }
     }
 
     func deleteSection(id: UUID, tab: PanelTab) {
@@ -216,7 +219,7 @@ final class Store: ObservableObject {
         next[tab] = list
         sectionsByTab = next
         try? Config.saveSections(next)
-        if tab == .issues { issuesBySectionId.removeValue(forKey: id) }
+        if tab == .issues || tab == .review { customSectionRows.removeValue(forKey: id) }
     }
 
     /// Moves `id` within `tab`. When `targetID` is nil, appends to the end.
@@ -285,14 +288,19 @@ final class Store: ObservableObject {
         pollTimer = nil
     }
 
-    private static func fetchIssueSections(
+    private static func fetchCustomSectionRows(
         client: GitHubClient,
         sections: [GitbarSection]
     ) async -> [UUID: [GHIssue]] {
         guard !sections.isEmpty else { return [:] }
         return await withTaskGroup(of: (UUID, [GHIssue]).self) { group in
             for section in sections {
-                let queries = section.remoteIssueSearchQueries()
+                let queries: [String]
+                switch section.tab {
+                case .issues: queries = section.remoteIssueSearchQueries()
+                case .review: queries = section.remoteReviewSearchQueries()
+                default: queries = []
+                }
                 guard !queries.isEmpty else { continue }
                 group.addTask {
                     var seen = Set<Int>()

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -7,7 +7,7 @@ enum PanelTab: String, CaseIterable, Identifiable, Codable, Sendable {
     var label: String {
         switch self {
         case .all: return "All"
-        case .mine: return "Mine"
+        case .mine: return "My PRs"
         case .review: return "Review"
         case .issues: return "Issues"
         case .stats: return "Stats"
@@ -170,11 +170,11 @@ struct PanelView: View {
     }
 
     private var listSignature: String {
-        let customIssueIds = store.issuesBySectionId
+        let customRowIds = store.customSectionRows
             .sorted { $0.key.uuidString < $1.key.uuidString }
             .map { "\($0.key.uuidString):\($0.value.map(\.id))" }
             .joined(separator: ",")
-        return "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.reviewedByMePRs.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))|\(customIssueIds)"
+        return "\(tab.rawValue)|\(store.myPRs.map(\.id))|\(store.reviewRequests.map(\.id))|\(store.reviewedByMePRs.map(\.id))|\(store.issues.map(\.id))|\(store.sections(for: .mine).map(\.id.uuidString))|\(store.sections(for: .review).map(\.id.uuidString))|\(store.sections(for: .issues).map(\.id.uuidString))|\(customRowIds)"
     }
 
     private let allTabPreviewLimit = 5
@@ -223,12 +223,17 @@ struct PanelView: View {
     }
 
     /// Rows for a single section. Issues-tab sections read remotely-fetched rows from the store
-    /// (each section runs its filters as a GitHub search). PR-tab sections filter `sourceRows`
-    /// locally via the matcher, with the Review tab splitting between the review-request queue
-    /// and reviewed-by-me PRs depending on the section's conditions.
+    /// (each section runs its filters as a GitHub search). Review-tab sections with a scoping
+    /// condition (`hasScopingCondition`) widen to the same per-section search and likewise read
+    /// from `customSectionRows`. Otherwise PR-tab sections filter `sourceRows` locally via the
+    /// matcher, with the Review tab splitting between the review-request queue and reviewed-by-me
+    /// PRs depending on the section's conditions.
     private func rowsForSection(_ section: GitbarSection, sourceRows: [GHIssue]) -> [GHIssue] {
         if section.tab == .issues {
-            return store.issuesBySectionId[section.id] ?? []
+            return store.customSectionRows[section.id] ?? []
+        }
+        if section.tab == .review, section.hasScopingCondition {
+            return store.customSectionRows[section.id] ?? []
         }
         let effectiveSource = sectionSource(for: section, tabSource: sourceRows)
         return effectiveSource.filter {
@@ -872,12 +877,18 @@ struct PanelView: View {
     private var showIssues: Bool { tab == .all || tab == .issues }
 
     private var isEmpty: Bool {
-        let customIssueRowCount = store.issuesBySectionId.values.reduce(0) { $0 + $1.count }
+        let customRowsForTab: (PanelTab) -> Int = { t in
+            self.store.sections(for: t)
+                .map { self.store.customSectionRows[$0.id]?.count ?? 0 }
+                .reduce(0, +)
+        }
+        let issuesCustomRows = customRowsForTab(.issues)
+        let reviewCustomRows = customRowsForTab(.review)
         return
             (tab == .all    && store.myPRs.isEmpty && store.reviewRequests.isEmpty && store.issues.isEmpty) ||
             (tab == .mine   && store.myPRs.isEmpty) ||
-            (tab == .review && store.reviewRequests.isEmpty && store.reviewedByMePRs.isEmpty) ||
-            (tab == .issues && store.issues.isEmpty && customIssueRowCount == 0)
+            (tab == .review && store.reviewRequests.isEmpty && store.reviewedByMePRs.isEmpty && reviewCustomRows == 0) ||
+            (tab == .issues && store.issues.isEmpty && issuesCustomRows == 0)
     }
 
     private var emptyState: some View {

--- a/Sources/Gitbar/Views/SectionEditorView.swift
+++ b/Sources/Gitbar/Views/SectionEditorView.swift
@@ -77,6 +77,9 @@ struct SectionEditorView: View {
                     if showsDefaultIssuesNotice {
                         defaultIssuesNotice
                     }
+                    if showsReviewWideningNotice {
+                        reviewWideningNotice
+                    }
                     nameSection
                     repositoriesSection
                     filtersSection
@@ -128,6 +131,16 @@ struct SectionEditorView: View {
         mode.tab == .issues && (mode.section?.isDefault ?? false)
     }
 
+    /// True when the live filter draft has any scoping condition (repo/author/assignee/label/reviewer)
+    /// with a non-empty value. Drives the widening notice and the editor's metadata-field hiding.
+    private var isReviewWidened: Bool {
+        mode.tab == .review && filters.contains { f in
+            f.conditions.contains(where: { $0.isScopingDraft })
+        }
+    }
+
+    private var showsReviewWideningNotice: Bool { isReviewWidened }
+
     private var defaultIssuesNotice: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "info.circle")
@@ -139,6 +152,30 @@ struct SectionEditorView: View {
                     .font(.system(size: 11.5, weight: .semibold))
                     .foregroundStyle(.primary)
                 Text("For custom scopes (a specific repo, label, or another user), create a new filter. You can hide this one under Visibility.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.meta)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Theme.blue.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8).stroke(Theme.blue.opacity(0.25), lineWidth: 0.5)
+        )
+    }
+
+    private var reviewWideningNotice: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.blue)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Filtering sections")
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text("Adding a scoping filter (Repository, Author, Assignee, Label, Reviewer, Reviewed by) extends this section to show all matching PRs across that scope, not just PRs awaiting your review.")
                     .font(.system(size: 10.5))
                     .foregroundStyle(Theme.meta)
                     .fixedSize(horizontal: false, vertical: true)
@@ -231,6 +268,12 @@ struct SectionEditorView: View {
                 .foregroundStyle(Theme.meta)
             if mode.tab == .issues, !(mode.section?.isDefault ?? false) {
                 Text("Runs as a GitHub search. Scope with a repo, label, author, or assignee — otherwise defaults to issues assigned to you.")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(Theme.meta)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            if mode.tab == .review {
+                Text("Review sections show open PRs unless you add a Status filter.")
                     .font(.system(size: 10.5))
                     .foregroundStyle(Theme.meta)
                     .fixedSize(horizontal: false, vertical: true)
@@ -354,40 +397,57 @@ struct SectionEditorView: View {
     @ViewBuilder
     private func conditionRow(filterIndex: Int, conditionIndex: Int, isFirstInFilter: Bool) -> some View {
         let binding = conditionBinding(filterIndex: filterIndex, conditionIndex: conditionIndex)
-        HStack(spacing: 8) {
-            Text(isFirstInFilter ? "Where" : "And")
-                .font(.system(size: 10.5, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: 42, alignment: .trailing)
+        let currentField = binding.wrappedValue.field
+        let stale = isReviewWidened && Self.metadataDependentFields.contains(currentField)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(isFirstInFilter ? "Where" : "And")
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 42, alignment: .trailing)
 
-            Picker("", selection: binding.field) {
-                ForEach(Self.availableFields(for: mode.tab)) { field in
-                    Text(field.label(for: mode.tab)).tag(field)
-                }
-            }
-            .labelsHidden()
-            .controlSize(.small)
-            .frame(width: conditionFieldWidth)
-
-            operatorPicker(for: binding)
-            valueEditor(for: binding)
-                .frame(width: conditionValueWidth, alignment: .leading)
-
-            Button {
-                if filters[filterIndex].conditions.count > 1 {
-                    withAnimation(.easeInOut(duration: 0.18)) {
-                        _ = filters[filterIndex].conditions.remove(at: conditionIndex)
+                Picker("", selection: binding.field) {
+                    ForEach(visibleFields(currentField: currentField)) { field in
+                        Text(field.label(for: mode.tab)).tag(field)
                     }
                 }
-            } label: {
-                Image(systemName: "minus.circle")
-                    .font(.system(size: 12))
-                    .foregroundStyle(filters[filterIndex].conditions.count > 1 ? Color.secondary : Color.secondary.opacity(0.3))
-                    .frame(width: 20, height: 20)
+                .labelsHidden()
+                .controlSize(.small)
+                .frame(width: conditionFieldWidth)
+
+                operatorPicker(for: binding)
+                valueEditor(for: binding)
+                    .frame(width: conditionValueWidth, alignment: .leading)
+
+                Button {
+                    if filters[filterIndex].conditions.count > 1 {
+                        withAnimation(.easeInOut(duration: 0.18)) {
+                            _ = filters[filterIndex].conditions.remove(at: conditionIndex)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "minus.circle")
+                        .font(.system(size: 12))
+                        .foregroundStyle(filters[filterIndex].conditions.count > 1 ? Color.secondary : Color.secondary.opacity(0.3))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .disabled(filters[filterIndex].conditions.count <= 1)
+                .help(filters[filterIndex].conditions.count > 1 ? "Remove condition" : "At least one condition is required")
             }
-            .buttonStyle(.plain)
-            .disabled(filters[filterIndex].conditions.count <= 1)
-            .help(filters[filterIndex].conditions.count > 1 ? "Remove condition" : "At least one condition is required")
+            if stale {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(Theme.amber)
+                    Text("Won't apply on widened sections — remove or drop the scoping filter to re-enable.")
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(Theme.meta)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                // Align the warning under the field picker: 42 ("Where" label width) + 8 (HStack spacing).
+                .padding(.leading, 50)
+            }
         }
         .padding(.leading, 8)
         .padding(.trailing, 12)
@@ -396,6 +456,17 @@ struct SectionEditorView: View {
         .overlay(
             RoundedRectangle(cornerRadius: 6).stroke(Theme.hairline(colorScheme), lineWidth: 0.5)
         )
+    }
+
+    /// Fields the picker should show. Hides metadata-dependent fields on widened Review
+    /// sections, but keeps the row's *current* field in the menu so existing instances
+    /// remain editable (and the warning row above it stays meaningful).
+    private func visibleFields(currentField: ConditionDraft.Field) -> [ConditionDraft.Field] {
+        let all = Self.availableFields(for: mode.tab)
+        guard isReviewWidened else { return all }
+        return all.filter { field in
+            !Self.metadataDependentFields.contains(field) || field == currentField
+        }
     }
 
     private func conditionBinding(filterIndex: Int, conditionIndex: Int) -> Binding<ConditionDraft> {
@@ -416,7 +487,7 @@ struct SectionEditorView: View {
             .labelsHidden()
             .controlSize(.small)
             .frame(width: operatorWidth)
-        case .author:
+        case .author, .reviewedBy:
             Picker("", selection: binding.eqOp) {
                 Text("is").tag(SectionEqOp.is_)
                 Text("is not").tag(SectionEqOp.isNot)
@@ -503,6 +574,11 @@ struct SectionEditorView: View {
                 all: ReviewedByMeStateValue.allCases.map { ($0, $0.label) },
                 selection: binding.reviewedByMeStates
             )
+        case .reviewedBy:
+            TextField("login or @me", text: binding.reviewedByLogin)
+                .textFieldStyle(.roundedBorder)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
         }
     }
 
@@ -653,11 +729,18 @@ struct SectionEditorView: View {
         case .mine:
             return [.prStatus, .author, .assignee, .repository, .label, .ciStatus, .draft]
         case .review:
-            return [.prStatus, .author, .assignee, .repository, .label, .ciStatus, .draft, .reviewedByMeState]
+            return [.prStatus, .author, .assignee, .repository, .label, .reviewer, .reviewedBy, .ciStatus, .draft, .reviewedByMeState]
         case .all, .stats:
             return [.prStatus, .author, .repository, .label]
         }
     }
+
+    /// Fields hidden from the picker on a widened Review-tab section because they require
+    /// per-PR metadata that isn't fetched for outside-queue PRs. Existing instances of these
+    /// on a now-widened section render an inline warning row instead.
+    fileprivate static let metadataDependentFields: Set<ConditionDraft.Field> = [
+        .ciStatus, .mergeConflict, .reviewedByMeState
+    ]
 
     private var visibilityHint: String {
         switch visibility {
@@ -706,9 +789,11 @@ struct ConditionDraft: Identifiable, Equatable {
     var isDraftValue: Bool = true
     var hasMergeConflictValue: Bool = true
     var reviewedByMeStates: Set<ReviewedByMeStateValue> = [.changesRequested, .commented]
+    var reviewedByLogin: String = "@me"
 
     enum Field: String, CaseIterable, Identifiable, Hashable {
         case prStatus, author, reviewer, assignee, repository, label, ciStatus, draft, mergeConflict, reviewedByMeState
+        case reviewedBy
 
         var id: String { rawValue }
         func label(for tab: PanelTab) -> String {
@@ -723,6 +808,7 @@ struct ConditionDraft: Identifiable, Equatable {
             case .draft: return "Draft"
             case .mergeConflict: return "Merge conflict"
             case .reviewedByMeState: return "Your review"
+            case .reviewedBy: return "Reviewed by"
             }
         }
     }
@@ -739,9 +825,10 @@ struct ConditionDraft: Identifiable, Equatable {
             field = .author
             eqOp = op
             authorLogin = login
-        case .reviewer:
-            // Legacy: this condition can't be evaluated reliably; fall back to PR status.
-            field = .prStatus
+        case .reviewer(let op, let login):
+            field = .reviewer
+            setOp = op
+            reviewerLogin = login
         case .ciStatus(let op, let values):
             field = .ciStatus
             setOp = op
@@ -768,6 +855,35 @@ struct ConditionDraft: Identifiable, Equatable {
             field = .reviewedByMeState
             setOp = op
             reviewedByMeStates = Set(values)
+        case .reviewedBy(let op, let login):
+            field = .reviewedBy
+            eqOp = op
+            reviewedByLogin = login
+        }
+    }
+
+    /// True when this draft would produce a scoping condition (repo / author / assignee /
+    /// label / reviewer / reviewedBy) with a non-empty value. Mirrors `SectionCondition.isScoping`
+    /// for the editor's live state — used to flip the widening notice and metadata-field hiding
+    /// as the user types.
+    var isScopingDraft: Bool {
+        switch field {
+        case .repository:
+            return repositoryText
+                .split(separator: ",")
+                .contains { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        case .author:
+            return !authorLogin.trimmingCharacters(in: .whitespaces).isEmpty
+        case .assignee:
+            return !assigneeLogin.trimmingCharacters(in: .whitespaces).isEmpty
+        case .label:
+            return !labelName.trimmingCharacters(in: .whitespaces).isEmpty
+        case .reviewer:
+            return !reviewerLogin.trimmingCharacters(in: .whitespaces).isEmpty
+        case .reviewedBy:
+            return !reviewedByLogin.trimmingCharacters(in: .whitespaces).isEmpty
+        case .prStatus, .ciStatus, .draft, .mergeConflict, .reviewedByMeState:
+            return false
         }
     }
 
@@ -809,6 +925,10 @@ struct ConditionDraft: Identifiable, Equatable {
         case .reviewedByMeState:
             guard !reviewedByMeStates.isEmpty else { return nil }
             return .reviewedByMeState(op: setOp, values: Array(reviewedByMeStates))
+        case .reviewedBy:
+            let trimmed = reviewedByLogin.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            return .reviewedBy(op: eqOp, login: trimmed)
         }
     }
 }


### PR DESCRIPTION
Fixes #16.

## Summary
- Review-tab sections widen to a per-section PR search when filters carry a scoping condition (repo / author / assignee / label / reviewer / `reviewedBy`). Without one, the section continues to filter the local review queue.
- New `reviewedBy` condition (supports `@me`) for "PRs reviewed by X".
- Editor surfaces a notice when widening kicks in, and inline-warns on conditions that won't apply (CI status, merge conflict, your review state) since those rely on per-PR metadata not fetched for outside-queue rows.
- Renames `Store.issuesBySectionId` → `customSectionRows` (now shared by Issues and widened Review sections).
- Restores `.reviewer` condition round-trip in the editor (previously fell back to `.prStatus` on load).
- Tab badges now dedupe across queues + widened/custom sections, fixing undercounts on Review (missed reviewed-by-me + widened rows), Issues (missed custom rows), and All.
- Renames the "Mine" tab label to "My PRs" (storage key unchanged).

## Test plan
- [ ] Add a Review section with `repo:owner/name` — verify it widens and shows PRs from that repo.
- [ ] Add a Review section with `reviewedBy:@me` — verify it shows PRs you've reviewed.
- [ ] Add a Review section with no scoping filter — verify it still filters the existing review queue.
- [ ] Open an existing section that uses `.reviewer` — verify the field is preserved across save/reload.
- [ ] Add a CI-status condition to a widened Review section — verify the inline warning row appears.
- [ ] Mix one scoping filter and one non-scoping filter in a widened section — verify the non-scoping filter falls back to `review-requested:@me` (still scoped to your queue).
- [ ] Confirm tab badges reflect total visible items (Review includes reviewed-by-me + widened section rows; Issues includes custom-section rows; All sums them, deduped).