### PR TITLE
Fix tab badge counts to dedupe and cover all sources

### DIFF
--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -864,12 +864,42 @@ struct PanelView: View {
 
     private func count(for t: PanelTab) -> Int {
         switch t {
-        case .all:    return store.myPRs.count + store.reviewRequests.count + store.issues.count
-        case .mine:   return store.myPRs.count
-        case .review: return store.reviewRequests.count
-        case .issues: return store.issues.count
-        case .stats:  return 0
+        case .all:
+            var ids = Set<Int>()
+            ids.formUnion(store.myPRs.map(\.id))
+            ids.formUnion(store.reviewRequests.map(\.id))
+            ids.formUnion(store.reviewedByMePRs.map(\.id))
+            ids.formUnion(store.issues.map(\.id))
+            ids.formUnion(customSectionRowIDs(in: [.review, .issues]))
+            return ids.count
+        case .mine:
+            return store.myPRs.count
+        case .review:
+            var ids = Set<Int>()
+            ids.formUnion(store.reviewRequests.map(\.id))
+            ids.formUnion(store.reviewedByMePRs.map(\.id))
+            ids.formUnion(customSectionRowIDs(in: [.review]))
+            return ids.count
+        case .issues:
+            var ids = Set<Int>()
+            ids.formUnion(store.issues.map(\.id))
+            ids.formUnion(customSectionRowIDs(in: [.issues]))
+            return ids.count
+        case .stats:
+            return 0
         }
+    }
+
+    private func customSectionRowIDs(in tabs: [PanelTab]) -> Set<Int> {
+        var ids = Set<Int>()
+        for tab in tabs {
+            for section in store.sections(for: tab) {
+                if let rows = store.customSectionRows[section.id] {
+                    ids.formUnion(rows.map(\.id))
+                }
+            }
+        }
+        return ids
     }
 
     private var showMine:   Bool { tab == .all || tab == .mine }


### PR DESCRIPTION
## Summary
- Tab badges now union IDs across `myPRs`, `reviewRequests`, `reviewedByMePRs`, `issues`, and custom-section rows so a PR appearing in multiple lists is only counted once.
- Review and All tabs now include `reviewedByMePRs` in their counts.
- Review and Issues tab counts include rows from any visible custom sections scoped to those tabs via a new `customSectionRowIDs(in:)` helper.

## Test plan
- [ ] Open the panel with overlapping PRs (e.g. one you authored that also requests your review) and confirm the All/Review badges no longer double-count.
- [ ] Add a PR you have already reviewed and confirm it contributes to the All and Review badges.
- [ ] Configure a custom section under Review and Issues; verify rows are reflected in those tab badges.
- [ ] Confirm Mine and Stats badge counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)