### PR TITLE
feat(auth): broker GitHub sign-in via gh CLI

### DIFF
--- a/Sources/Gitbar/App.swift
+++ b/Sources/Gitbar/App.swift
@@ -32,6 +32,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if store.hasToken {
             store.refresh()
             store.reconfigurePollingFromDefaults()
+        } else {
+            Task { @MainActor in
+                await store.tryAutoImportFromGHCLI()
+            }
         }
 
         updater.start()

--- a/Sources/Gitbar/GHCLIAuth.swift
+++ b/Sources/Gitbar/GHCLIAuth.swift
@@ -1,0 +1,290 @@
+import Foundation
+
+/// Wraps the `gh` GitHub CLI binary so Gitbar can broker authentication
+/// without asking the user to paste a personal access token. Three flows:
+///
+///   1. `status()` reports whether `gh` is installed and signed in.
+///   2. `token()` reads `gh auth token` for an already-signed-in user.
+///   3. `deviceLogin()` drives `gh auth login --web` and streams the
+///      one-time code + verification URL so SwiftUI can render an
+///      inline sign-in screen.
+enum GHCLIAuth {
+    enum Status: Equatable {
+        case notInstalled
+        case installedNotAuthed
+        case authed(host: String)
+    }
+
+    enum DeviceLoginEvent {
+        case userCode(String)
+        case verificationURL(URL)
+        case completed
+    }
+
+    enum GHCLIError: LocalizedError {
+        case notInstalled
+        case notAuthed
+        case processFailed(Int32, String)
+        case missingScope
+
+        var errorDescription: String? {
+            switch self {
+            case .notInstalled:
+                return "GitHub CLI (gh) is not installed."
+            case .notAuthed:
+                return "GitHub CLI is not signed in."
+            case .processFailed(let code, let msg):
+                let trimmed = msg.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty
+                    ? "gh exited with status \(code)."
+                    : "gh: \(trimmed)"
+            case .missingScope:
+                return "Token is missing the `repo` scope. Run `gh auth refresh -s repo` and try again."
+            }
+        }
+    }
+
+    /// Locate `gh` via login-shell `command -v gh` so Homebrew (Apple Silicon
+    /// `/opt/homebrew/bin`, Intel `/usr/local/bin`) and MacPorts paths resolve
+    /// even when GUI apps inherit a stripped PATH.
+    static func locate() -> URL? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        proc.arguments = ["-lc", "command -v gh"]
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = Pipe()
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            let data = out.fileHandleForReading.readDataToEndOfFile()
+            let path = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+        } catch {
+            // Fall through to fixed-path probe.
+        }
+
+        for candidate in ["/opt/homebrew/bin/gh", "/usr/local/bin/gh", "/usr/bin/gh"] {
+            if FileManager.default.isExecutableFile(atPath: candidate) {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+
+    static func status() async -> Status {
+        guard let gh = locate() else { return .notInstalled }
+        let result = await runProcess(executable: gh, arguments: ["auth", "status", "--hostname", "github.com"])
+        return result.status == 0 ? .authed(host: "github.com") : .installedNotAuthed
+    }
+
+    /// Reads `gh auth token --hostname github.com`. Throws if not installed
+    /// or not signed in.
+    static func token() async throws -> String {
+        guard let gh = locate() else { throw GHCLIError.notInstalled }
+        let result = await runProcess(executable: gh, arguments: ["auth", "token", "--hostname", "github.com"])
+        if result.status != 0 {
+            throw GHCLIError.notAuthed
+        }
+        let token = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if token.isEmpty {
+            throw GHCLIError.notAuthed
+        }
+        return token
+    }
+
+    /// Reads the gh-managed token and verifies it carries the `repo` scope by
+    /// hitting `GET /user`. We don't parse `gh auth status` output (the format
+    /// varies by version); a real API call is the source of truth.
+    static func tokenWithScopeCheck() async throws -> String {
+        let token = try await token()
+        var req = URLRequest(url: URL(string: "https://api.github.com/user")!)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        req.setValue("gitbar/0.1", forHTTPHeaderField: "User-Agent")
+
+        let (_, resp) = try await URLSession.shared.data(for: req)
+        guard let http = resp as? HTTPURLResponse else {
+            throw GHCLIError.processFailed(-1, "no response from GitHub API")
+        }
+        if http.statusCode == 401 || http.statusCode == 403 {
+            throw GHCLIError.missingScope
+        }
+        if !(200..<300).contains(http.statusCode) {
+            throw GHCLIError.processFailed(Int32(http.statusCode), "GitHub API error")
+        }
+
+        // GitHub returns granted scopes in `X-OAuth-Scopes` for classic tokens.
+        // Fine-grained PATs lack this header — we trust the 200 OK in that case.
+        if let scopes = http.value(forHTTPHeaderField: "X-OAuth-Scopes"),
+           !scopes.isEmpty {
+            let granted = Set(scopes.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) })
+            if !granted.contains("repo") && !granted.contains("public_repo") {
+                throw GHCLIError.missingScope
+            }
+        }
+        return token
+    }
+
+    /// Streaming `gh auth login --web`. Emits the user code and verification
+    /// URL as soon as `gh` prints them, then `.completed` when the polling
+    /// finishes successfully. Cancel by terminating the underlying stream.
+    static func deviceLogin() -> AsyncThrowingStream<DeviceLoginEvent, Error> {
+        AsyncThrowingStream { continuation in
+            guard let gh = locate() else {
+                continuation.finish(throwing: GHCLIError.notInstalled)
+                return
+            }
+
+            let process = Process()
+            process.executableURL = gh
+            process.arguments = [
+                "auth", "login",
+                "--hostname", "github.com",
+                "--web",
+                "--scopes", "repo",
+                "--git-protocol", "https",
+            ]
+
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            let stdinPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+            process.standardInput = stdinPipe
+
+            let state = DeviceLoginParser(continuation: continuation, stdin: stdinPipe.fileHandleForWriting)
+
+            stderrPipe.fileHandleForReading.readabilityHandler = { fh in
+                state.feed(fh.availableData)
+            }
+            stdoutPipe.fileHandleForReading.readabilityHandler = { fh in
+                state.feed(fh.availableData)
+            }
+
+            process.terminationHandler = { p in
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                if p.terminationStatus == 0 {
+                    continuation.yield(.completed)
+                    continuation.finish()
+                } else {
+                    let trailing = state.snapshot()
+                    continuation.finish(throwing: GHCLIError.processFailed(p.terminationStatus, trailing))
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+
+            continuation.onTermination = { _ in
+                if process.isRunning { process.terminate() }
+            }
+        }
+    }
+
+    private static func runProcess(executable: URL, arguments: [String]) async -> (status: Int32, stdout: String, stderr: String) {
+        await withCheckedContinuation { cont in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let p = Process()
+                p.executableURL = executable
+                p.arguments = arguments
+                let out = Pipe()
+                let err = Pipe()
+                p.standardOutput = out
+                p.standardError = err
+                do {
+                    try p.run()
+                    p.waitUntilExit()
+                    let outData = out.fileHandleForReading.readDataToEndOfFile()
+                    let errData = err.fileHandleForReading.readDataToEndOfFile()
+                    cont.resume(returning: (
+                        p.terminationStatus,
+                        String(data: outData, encoding: .utf8) ?? "",
+                        String(data: errData, encoding: .utf8) ?? ""
+                    ))
+                } catch {
+                    cont.resume(returning: (-1, "", error.localizedDescription))
+                }
+            }
+        }
+    }
+}
+
+/// Buffers gh's interleaved stdout/stderr, extracts the first matching
+/// user code (`ABCD-1234`) and verification URL, then writes a newline to
+/// gh's stdin so it stops waiting on "Press Enter…" and starts polling.
+private final class DeviceLoginParser: @unchecked Sendable {
+    private let continuation: AsyncThrowingStream<GHCLIAuth.DeviceLoginEvent, Error>.Continuation
+    private let stdin: FileHandle
+    private let lock = NSLock()
+    private var buffer = ""
+    private var sawCode = false
+    private var sawURL = false
+    private var pokedStdin = false
+
+    private static let codeRegex = try! NSRegularExpression(pattern: #"([A-Z0-9]{4}-[A-Z0-9]{4})"#)
+    private static let urlRegex = try! NSRegularExpression(pattern: #"https://github\.com/login/device"#)
+
+    init(
+        continuation: AsyncThrowingStream<GHCLIAuth.DeviceLoginEvent, Error>.Continuation,
+        stdin: FileHandle
+    ) {
+        self.continuation = continuation
+        self.stdin = stdin
+    }
+
+    func feed(_ data: Data) {
+        guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+        lock.lock()
+        buffer.append(chunk)
+        let snapshot = buffer
+        let alreadySawCode = sawCode
+        let alreadySawURL = sawURL
+        lock.unlock()
+
+        if !alreadySawCode {
+            let range = NSRange(snapshot.startIndex..<snapshot.endIndex, in: snapshot)
+            if let match = Self.codeRegex.firstMatch(in: snapshot, range: range),
+               let r = Range(match.range(at: 1), in: snapshot) {
+                lock.lock(); sawCode = true; lock.unlock()
+                continuation.yield(.userCode(String(snapshot[r])))
+            }
+        }
+        if !alreadySawURL {
+            let range = NSRange(snapshot.startIndex..<snapshot.endIndex, in: snapshot)
+            if let match = Self.urlRegex.firstMatch(in: snapshot, range: range),
+               let r = Range(match.range, in: snapshot),
+               let url = URL(string: String(snapshot[r])) {
+                lock.lock(); sawURL = true; lock.unlock()
+                continuation.yield(.verificationURL(url))
+            }
+        }
+
+        lock.lock()
+        let shouldPoke = sawCode && sawURL && !pokedStdin
+        if shouldPoke { pokedStdin = true }
+        lock.unlock()
+
+        if shouldPoke {
+            // Unblock gh's "Press Enter to open …" prompt so it begins polling.
+            // We drive the browser ourselves from SwiftUI; gh's own `open`
+            // call is a harmless no-op duplicate.
+            try? stdin.write(contentsOf: Data("\n".utf8))
+            try? stdin.close()
+        }
+    }
+
+    func snapshot() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return buffer
+    }
+}

--- a/Sources/Gitbar/Store.swift
+++ b/Sources/Gitbar/Store.swift
@@ -30,6 +30,15 @@ final class Store: ObservableObject {
     @Published var errorMessage: String?
     @Published var token: String?
     @Published var sectionsByTab: [PanelTab: [GitbarSection]] = [:]
+    /// Cached result of `gh auth status`. Drives the "Sign in with GitHub CLI"
+    /// affordance in the empty state and Settings.
+    @Published var ghCLIStatus: GHCLIAuth.Status = .notInstalled
+    /// One-shot flag set when the launch-time auto-import succeeds. Cleared by
+    /// `PanelView` after the banner is shown / dismissed.
+    @Published var didAutoImportFromCLI = false
+    /// Surfaced by the CLI sign-in flow when `gh` returns a token without the
+    /// `repo` scope, so the Settings UI can render a remediation hint.
+    @Published var ghCLIErrorMessage: String?
 
     /// Stats tab (`StatsLoader` + GitHub Search / events).
     @Published private(set) var statsSnapshot: StatsSnapshot?
@@ -259,10 +268,52 @@ final class Store: ObservableObject {
             statsError = nil
             errorMessage = nil
             lastRefreshed = nil
+            didAutoImportFromCLI = false
+            ghCLIErrorMessage = nil
         }
         reconfigurePollingFromDefaults()
         if !trimmed.isEmpty {
             refresh()
+        }
+    }
+
+    /// Re-runs `gh auth status` and publishes the result. Cheap (sub-second);
+    /// called on launch and when Settings opens.
+    func refreshGHCLIStatus() async {
+        let status = await GHCLIAuth.status()
+        self.ghCLIStatus = status
+    }
+
+    /// Launch-time silent import. Only runs when no token is stored. On
+    /// success, flips `didAutoImportFromCLI` so the panel shows a banner.
+    func tryAutoImportFromGHCLI() async {
+        await refreshGHCLIStatus()
+        guard case .authed = ghCLIStatus else { return }
+        guard !hasToken else { return }
+        do {
+            let token = try await GHCLIAuth.tokenWithScopeCheck()
+            updateToken(token)
+            didAutoImportFromCLI = true
+        } catch {
+            ghCLIErrorMessage = error.localizedDescription
+        }
+    }
+
+    /// Explicit user-initiated import (Settings "Import token" or empty-state
+    /// button when `gh` is already signed in). Returns `true` if the token
+    /// was imported; `false` means the caller should switch to the device
+    /// login flow.
+    func importTokenFromGHCLI() async -> Bool {
+        await refreshGHCLIStatus()
+        guard case .authed = ghCLIStatus else { return false }
+        do {
+            let token = try await GHCLIAuth.tokenWithScopeCheck()
+            ghCLIErrorMessage = nil
+            updateToken(token)
+            return true
+        } catch {
+            ghCLIErrorMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/Sources/Gitbar/Views/CLISignInView.swift
+++ b/Sources/Gitbar/Views/CLISignInView.swift
@@ -1,0 +1,268 @@
+import SwiftUI
+import AppKit
+
+/// Inline sign-in screen presented as a sheet from the empty-state panel and
+/// from Settings. Drives `gh auth login --web`, displays the one-time code,
+/// and offers a one-click "Open browser" jump to https://github.com/login/device.
+struct CLISignInView: View {
+    @EnvironmentObject var store: Store
+    @Environment(\.colorScheme) private var scheme
+    let onClose: () -> Void
+
+    @StateObject private var model = CLISignInModel()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            header
+            Divider().opacity(0.4)
+            content
+            footer
+        }
+        .padding(20)
+        .frame(width: 380)
+        .background(VisualEffect(material: .popover, blendingMode: .behindWindow))
+        .task { await model.start(store: store) }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "terminal.fill")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(Theme.blue)
+                .frame(width: 28, height: 28)
+                .background(Theme.blue.opacity(0.14), in: RoundedRectangle(cornerRadius: 7))
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Sign in with GitHub CLI")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Gitbar will use `gh` to authorize your account.")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                model.cancel()
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .detecting:
+            phaseRow(systemImage: "ellipsis.circle", title: "Checking GitHub CLI…", showSpinner: true)
+        case .needCode:
+            needCode
+        case .success(let login):
+            phaseRow(
+                systemImage: "checkmark.circle.fill",
+                title: "Signed in as @\(login)",
+                tint: Theme.green
+            )
+        case .error(let message):
+            errorState(message: message)
+        }
+    }
+
+    private var needCode: some View {
+        VStack(spacing: 12) {
+            VStack(spacing: 4) {
+                Text("Enter this one-time code")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Theme.meta)
+                Text(model.userCode ?? "····-····")
+                    .font(.system(size: 22, weight: .bold, design: .monospaced))
+                    .tracking(2)
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 18)
+                    .background(Theme.surface(scheme), in: RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Theme.hairline(scheme), lineWidth: 1)
+                    )
+            }
+
+            HStack(spacing: 8) {
+                Button {
+                    if let code = model.userCode {
+                        let pb = NSPasteboard.general
+                        pb.clearContents()
+                        pb.setString(code, forType: .string)
+                        model.didCopyCode = true
+                    }
+                } label: {
+                    Label(model.didCopyCode ? "Copied" : "Copy code",
+                          systemImage: model.didCopyCode ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 12, weight: .medium))
+                }
+                .buttonStyle(.bordered)
+                .disabled(model.userCode == nil)
+
+                Button {
+                    if let url = model.verificationURL {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Label("Open browser", systemImage: "arrow.up.right.square")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(model.verificationURL == nil)
+            }
+
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Waiting for authorization in your browser…")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func errorState(message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 22))
+                .foregroundStyle(Theme.amber)
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Button("Try again") {
+                    Task { await model.restart(store: store) }
+                }
+                .buttonStyle(.bordered)
+                Button("Use a token instead") {
+                    onClose()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private func phaseRow(
+        systemImage: String,
+        title: String,
+        showSpinner: Bool = false,
+        tint: Color = Theme.blue
+    ) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(tint)
+            Text(title)
+                .font(.system(size: 13))
+            if showSpinner {
+                ProgressView().controlSize(.small)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+
+    private var footer: some View {
+        HStack {
+            Text("`gh` runs locally — your credentials never leave your machine.")
+                .font(.system(size: 10.5))
+                .foregroundStyle(Theme.faint)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+    }
+}
+
+@MainActor
+final class CLISignInModel: ObservableObject {
+    enum Phase: Equatable {
+        case detecting
+        case needCode
+        case success(login: String)
+        case error(String)
+    }
+
+    @Published var phase: Phase = .detecting
+    @Published var userCode: String?
+    @Published var verificationURL: URL?
+    @Published var didCopyCode = false
+
+    private var loginTask: Task<Void, Never>?
+
+    func start(store: Store) async {
+        await refreshAndRoute(store: store)
+    }
+
+    func restart(store: Store) async {
+        cancel()
+        userCode = nil
+        verificationURL = nil
+        didCopyCode = false
+        phase = .detecting
+        await refreshAndRoute(store: store)
+    }
+
+    func cancel() {
+        loginTask?.cancel()
+        loginTask = nil
+    }
+
+    private func refreshAndRoute(store: Store) async {
+        await store.refreshGHCLIStatus()
+
+        switch store.ghCLIStatus {
+        case .notInstalled:
+            phase = .error("GitHub CLI (gh) is not installed. Install it from https://cli.github.com.")
+            return
+        case .authed:
+            // Already signed in to gh — short-circuit straight to import.
+            await importExistingToken(store: store)
+        case .installedNotAuthed:
+            phase = .needCode
+            startDeviceLogin(store: store)
+        }
+    }
+
+    private func importExistingToken(store: Store) async {
+        let ok = await store.importTokenFromGHCLI()
+        if ok {
+            phase = .success(login: store.viewer?.login ?? store.myLogin ?? "you")
+        } else {
+            phase = .error(store.ghCLIErrorMessage ?? "Couldn't read the token from `gh`.")
+        }
+    }
+
+    private func startDeviceLogin(store: Store) {
+        loginTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = GHCLIAuth.deviceLogin()
+            do {
+                for try await event in stream {
+                    if Task.isCancelled { return }
+                    switch event {
+                    case .userCode(let code):
+                        self.userCode = code
+                    case .verificationURL(let url):
+                        self.verificationURL = url
+                    case .completed:
+                        await self.importExistingToken(store: store)
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                if !Task.isCancelled {
+                    self.phase = .error(error.localizedDescription)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Gitbar/Views/PanelView.swift
+++ b/Sources/Gitbar/Views/PanelView.swift
@@ -129,6 +129,11 @@ struct PanelView: View {
                 tabBar
                     .animation(.easeInOut(duration: 0.16), value: tab)
                 panelDivider
+                if store.didAutoImportFromCLI {
+                    AutoImportBanner()
+                        .environmentObject(store)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
             content
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -139,6 +144,7 @@ struct PanelView: View {
                 footer
             }
         }
+        .animation(.easeInOut(duration: 0.18), value: store.didAutoImportFromCLI)
     }
 
     private var overlayIdentity: String {
@@ -865,25 +871,115 @@ struct PanelView: View {
 }
 
 struct EmptyTokenState: View {
+    @EnvironmentObject var store: Store
     let onOpenSettings: () -> Void
+
+    @State private var showCLISignIn = false
+    @State private var ghDetected = false
+
+    private var hasGH: Bool { ghDetected }
+
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 12) {
             Spacer()
-            Image(systemName: "key.horizontal")
+            Image(systemName: hasGH ? "terminal.fill" : "key.horizontal")
                 .font(.system(size: 26))
-                .foregroundStyle(Theme.amber)
-            Text("Add a GitHub token")
+                .foregroundStyle(hasGH ? Theme.blue : Theme.amber)
+            Text(hasGH ? "Sign in with GitHub CLI" : "Add a GitHub token")
                 .font(.system(size: 14, weight: .semibold))
-            Text("Gitbar needs a personal access token to read PRs and issues.")
+            Text(hasGH
+                 ? "We detected `gh` on your machine. Use it to sign in without copying a token."
+                 : "Gitbar needs a personal access token to read PRs and issues.")
                 .font(.system(size: 11.5))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
-            Button("Open settings", action: onOpenSettings)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
+
+            if hasGH {
+                VStack(spacing: 6) {
+                    Button {
+                        showCLISignIn = true
+                    } label: {
+                        Label("Continue with GitHub CLI", systemImage: "terminal")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+
+                    Button("Use a token instead", action: onOpenSettings)
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Button("Open settings", action: onOpenSettings)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+            }
             Spacer()
         }
         .frame(maxWidth: .infinity)
+        .task {
+            await store.refreshGHCLIStatus()
+            ghDetected = store.ghCLIStatus != .notInstalled
+        }
+        .onChange(of: store.ghCLIStatus) { _, new in
+            ghDetected = new != .notInstalled
+        }
+        .sheet(isPresented: $showCLISignIn) {
+            CLISignInView(onClose: { showCLISignIn = false })
+                .environmentObject(store)
+        }
+    }
+}
+
+/// Shown briefly at the top of the panel after a launch-time CLI auto-import.
+struct AutoImportBanner: View {
+    @EnvironmentObject var store: Store
+    @Environment(\.colorScheme) private var scheme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Theme.green)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Signed in via GitHub CLI")
+                    .font(.system(size: 12, weight: .semibold))
+                if let login = store.viewer?.login ?? store.myLogin {
+                    Text("@\(login)")
+                        .font(Theme.mono)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            Button {
+                withAnimation(.easeInOut(duration: 0.18)) {
+                    store.didAutoImportFromCLI = false
+                }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Theme.green.opacity(0.10))
+        .overlay(
+            Rectangle()
+                .fill(Theme.green.opacity(0.25))
+                .frame(height: 1),
+            alignment: .bottom
+        )
+        .task {
+            // Auto-dismiss after ~5s; user can still click X earlier.
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            withAnimation(.easeInOut(duration: 0.25)) {
+                store.didAutoImportFromCLI = false
+            }
+        }
     }
 }

--- a/Sources/Gitbar/Views/SettingsView.swift
+++ b/Sources/Gitbar/Views/SettingsView.swift
@@ -7,6 +7,8 @@ struct SettingsView: View {
 
     @State private var tokenField: String = ""
     @State private var tokenVisible = false
+    @State private var showCLISignIn = false
+    @State private var cliBusy = false
     @AppStorage("gitbar.notify.reviewRequests") private var notifyReviews = true
     @AppStorage("gitbar.notify.ci") private var notifyCI = true
     @AppStorage("gitbar.notify.changesRequested") private var notifyChangesRequested = true
@@ -67,6 +69,8 @@ struct SettingsView: View {
             }
 
             Section("Personal access token") {
+                ghCLIRow
+
                 HStack(spacing: 6) {
                     TokenField(
                         text: $tokenField,
@@ -234,6 +238,107 @@ struct SettingsView: View {
         .onAppear {
             tokenField = store.token ?? ""
             launchAtLogin = LaunchAtLogin.isEnabled
+        }
+        .task {
+            await store.refreshGHCLIStatus()
+        }
+        .sheet(isPresented: $showCLISignIn) {
+            CLISignInView(onClose: {
+                showCLISignIn = false
+                tokenField = store.token ?? ""
+            })
+            .environmentObject(store)
+        }
+    }
+
+    @ViewBuilder
+    private var ghCLIRow: some View {
+        switch store.ghCLIStatus {
+        case .notInstalled:
+            HStack(spacing: 10) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Theme.faint)
+                    .frame(width: 22, height: 22)
+                    .background(Theme.faint.opacity(0.10), in: RoundedRectangle(cornerRadius: 5))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("GitHub CLI not detected")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Install `gh` to skip the manual token paste.")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Link("Install", destination: URL(string: "https://cli.github.com")!)
+                    .font(.system(size: 11.5, weight: .medium))
+            }
+            .padding(.vertical, 2)
+        case .authed:
+            HStack(spacing: 10) {
+                Image(systemName: "terminal.fill")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Theme.green)
+                    .frame(width: 22, height: 22)
+                    .background(Theme.green.opacity(0.14), in: RoundedRectangle(cornerRadius: 5))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("GitHub CLI signed in")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Import the token gh manages for you.")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button(cliBusy ? "Importing…" : "Import token") {
+                    cliBusy = true
+                    Task {
+                        let ok = await store.importTokenFromGHCLI()
+                        cliBusy = false
+                        if ok {
+                            tokenField = store.token ?? ""
+                        }
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(cliBusy)
+            }
+            .padding(.vertical, 2)
+        case .installedNotAuthed:
+            HStack(spacing: 10) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Theme.amber)
+                    .frame(width: 22, height: 22)
+                    .background(Theme.amber.opacity(0.14), in: RoundedRectangle(cornerRadius: 5))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("GitHub CLI detected")
+                        .font(.system(size: 12, weight: .medium))
+                    Text("Not signed in to gh yet — we'll guide you through it.")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Sign in via gh") {
+                    showCLISignIn = true
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding(.vertical, 2)
+        }
+
+        if let err = store.ghCLIErrorMessage {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.amber)
+                Text(err)
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+            }
+            .padding(.vertical, 2)
         }
     }
 


### PR DESCRIPTION
Today, Gitbar onboarding requires the user to (1) open Settings, (2) generate a classic or fine-grained PAT on github.com with the right scopes, and (3) paste it into the token field. Many of our users   (like me) already have the GitHub CLI (gh) installed and authenticated for everyday work, so this duplicates effort and is a friction point on first launch.

This PR will allow `gitbar` to use `gh` as a credential broker to remove that friction:

If the user is already signed in to gh, silently import their token on app launch with a non-blocking banner so they know what happened.

If `gh` is installed but not signed in, drive `gh auth login --web` ourselves via Process, parse the device code, and render an inline SwiftUI screen with a one-click “Open browser” button. No Terminal involvement.

If `gh` isn’t installed, fall back to today’s manual PAT flow.

The token continues to live where it does today (~/.gitbar/config.json → github.token), so no migration or revocation flow is needed. PAT pasting stays as a fallback.

## Demo

https://github.com/user-attachments/assets/2bb98d45-fed5-4d8c-9320-28dd38313b91

Here are some of the technical details for those interested: 

- Auto-import the GitHub token from `gh auth token` on launch when no token is stored, surfacing a one-time green banner so the user knows the sign-in came from the CLI.
- Add a "Continue with GitHub CLI" path to the empty-state panel that drives `gh auth login --web` via Process, parses the device code + verification URL from stderr, and renders an inline SwiftUI sheet with a one-click "Open browser" button.
- Add a "GitHub CLI" row to the Personal access token section in Settings that reflects the three detected states (not installed / signed in / installed-not-signed-in) with the matching action.
- Verify the imported token actually carries the `repo` scope via `GET /user` before persisting; surface a remediation hint if it doesn't.

Token storage at `~/.gitbar/config.json` is unchanged — the CLI flows funnel through the existing `Store.updateToken(_:)` ingress so PAT pasting still works as a fallback.