### PR TITLE
show author/assignee avatars in PR and issue rows

### DIFF
--- a/Sources/Gitbar/Views/AvatarView.swift
+++ b/Sources/Gitbar/Views/AvatarView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import AppKit
+
+/// Disk + memory cached loader for GitHub user avatars.
+///
+/// Uses a dedicated `URLCache` under `~/Library/Caches/Gitbar/avatars` for the
+/// raw response bytes (URLSession respects HTTP cache headers; GitHub's avatar
+/// CDN sets long max-age) plus an in-memory `NSCache` of decoded `NSImage` so
+/// re-renders don't redecode PNGs.
+@MainActor
+final class AvatarCache {
+    static let shared = AvatarCache()
+
+    private let memory = NSCache<NSURL, NSImage>()
+    private let session: URLSession
+
+    private init() {
+        memory.countLimit = 256
+
+        let dir = FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first!
+            .appendingPathComponent("Gitbar/avatars", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let urlCache = URLCache(
+            memoryCapacity: 4 * 1024 * 1024,
+            diskCapacity: 64 * 1024 * 1024,
+            directory: dir
+        )
+        let cfg = URLSessionConfiguration.default
+        cfg.urlCache = urlCache
+        cfg.requestCachePolicy = .returnCacheDataElseLoad
+        cfg.timeoutIntervalForRequest = 15
+        self.session = URLSession(configuration: cfg)
+    }
+
+    func image(for url: URL) async -> NSImage? {
+        if let cached = memory.object(forKey: url as NSURL) {
+            return cached
+        }
+        guard let (data, _) = try? await session.data(from: url),
+              let img = NSImage(data: data) else {
+            return nil
+        }
+        memory.setObject(img, forKey: url as NSURL)
+        return img
+    }
+}
+
+/// Round avatar with a fallback monogram while loading or on failure.
+struct AvatarView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let url: String?
+    let login: String
+    var size: CGFloat = 14
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.medium)
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                Text(monogram)
+                    .font(.system(size: size * 0.55, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: size, height: size)
+                    .background(Theme.surfaceHi(colorScheme))
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(
+            Circle().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+        .task(id: url) {
+            guard let s = url, let u = URL(string: s) else {
+                image = nil
+                return
+            }
+            image = await AvatarCache.shared.image(for: u)
+        }
+    }
+
+    private var monogram: String {
+        String(login.first.map(Character.init) ?? "?").uppercased()
+    }
+}
+
+/// AppKit-backed tooltip that's more reliable than SwiftUI's `.help()` inside
+/// custom layouts (FlowLayout) and Button labels. Drop in as `.tooltip("…")`.
+struct ToolTip: NSViewRepresentable {
+    let text: String
+
+    func makeNSView(context: Context) -> NSView {
+        let v = NSView(frame: .zero)
+        v.toolTip = text
+        return v
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        nsView.toolTip = text
+    }
+}
+
+extension View {
+    func tooltip(_ text: String) -> some View {
+        overlay(ToolTip(text: text))
+    }
+}

--- a/Sources/Gitbar/Views/Chips.swift
+++ b/Sources/Gitbar/Views/Chips.swift
@@ -40,6 +40,7 @@ struct AssigneeChip: View {
     @Environment(\.colorScheme) private var colorScheme
     @EnvironmentObject private var store: Store
     let login: String
+    var avatarUrl: String? = nil
 
     private var displayText: String {
         if let me = store.myLogin, login.caseInsensitiveCompare(me) == .orderedSame {
@@ -49,12 +50,16 @@ struct AssigneeChip: View {
     }
 
     var body: some View {
-        Text(displayText)
-            .font(.system(size: 10, weight: .medium))
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1)
-            .background(Theme.surfaceHi(colorScheme), in: RoundedRectangle(cornerRadius: 4))
+        HStack(spacing: 4) {
+            AvatarView(url: avatarUrl, login: login, size: 13)
+            Text(displayText)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.leading, 2)
+        .padding(.trailing, 6)
+        .padding(.vertical, 1)
+        .background(Theme.surfaceHi(colorScheme), in: Capsule(style: .continuous))
     }
 }
 

--- a/Sources/Gitbar/Views/Rows.swift
+++ b/Sources/Gitbar/Views/Rows.swift
@@ -90,7 +90,7 @@ struct PRRow: View {
 
                     if showAuthor {
                         Text("·").foregroundStyle(Theme.faint.opacity(0.9))
-                        AssigneeChip(login: pr.user.login)
+                        AssigneeChip(login: pr.user.login, avatarUrl: pr.user.avatarUrl)
                     }
 
                     if metadata?.hasMergeConflict == true {
@@ -241,9 +241,14 @@ struct IssueRow: View {
                     let assignees = issue.assignees ?? []
                     dotSeparator
                     if let first = assignees.first {
-                        AssigneeChip(login: first.login)
                         if assignees.count > 1 {
-                            OverflowPill(count: assignees.count - 1)
+                            HStack(spacing: 4) {
+                                AssigneeChip(login: first.login, avatarUrl: first.avatarUrl)
+                                OverflowPill(count: assignees.count - 1)
+                            }
+                            .tooltip(assignees.map { "@\($0.login)" }.joined(separator: ", "))
+                        } else {
+                            AssigneeChip(login: first.login, avatarUrl: first.avatarUrl)
                         }
                     } else {
                         UnassignedChip()


### PR DESCRIPTION
## Summary
- PR rows render the author's avatar next to `@login`; issue rows render the first assignee's avatar plus a `+N` pill when there are multiple assignees.
- The chip + overflow pill share an AppKit-backed tooltip (`NSView.toolTip`) listing every assignee, since SwiftUI's `.help()` is unreliable inside `FlowLayout` and Button labels.
- Avatars load through a dedicated `URLCache` (4 MB memory / 64 MB disk under `~/Library/Caches/Gitbar/avatars`) plus an in-memory `NSCache<NSURL, NSImage>` of decoded images, so a 50-row menu doesn't hammer the GitHub avatar CDN on each open.
- No model changes — `GHUser.avatarUrl` and `GHIssue.assignees[].avatarUrl` were already decoded from `/search/issues`.

## Test plan
- [ ] Open menu, confirm PR rows show author avatar + `@login` capsule
- [ ] Open menu, confirm single-assignee issues show one avatar chip
- [ ] Open menu, find a multi-assignee issue, confirm `+N` pill is shown
- [ ] Hover the assignee group on a multi-assignee issue, confirm tooltip lists all `@logins`
- [ ] Reopen menu after first load, confirm avatars appear instantly (cache hit)
- [ ] Toggle Light/Dark mode, confirm the capsule background and avatar border still read well